### PR TITLE
Fixes bug where tab icons are not centered when fullscreen, resolves #47

### DIFF
--- a/Lumidex/App.axaml
+++ b/Lumidex/App.axaml
@@ -11,6 +11,9 @@
     </Application.DataTemplates>
 
     <Application.Styles>
+        <Style Selector="Window[WindowState=Maximized]">
+            <Setter Property="Padding" Value="8" />
+        </Style>
         <FluentTheme>
             <FluentTheme.Palettes>
                 <ColorPaletteResources
@@ -48,5 +51,4 @@
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <dialogHostAvalonia:DialogHostStyles />
     </Application.Styles>
-
 </Application>

--- a/Lumidex/Features/Main/MainWindow.axaml
+++ b/Lumidex/Features/Main/MainWindow.axaml
@@ -26,9 +26,4 @@
         OverlayBackground="#44dddddd">
         <main:MainView />
     </dialogs:ReactiveDialogHost>
-    <Window.Styles>
-        <Style Selector="Window[WindowState=Maximized]">
-            <Setter Property="Padding" Value="8" />
-        </Style>
-    </Window.Styles>
 </Window>

--- a/Lumidex/Features/Main/MainWindow.axaml
+++ b/Lumidex/Features/Main/MainWindow.axaml
@@ -26,4 +26,9 @@
         OverlayBackground="#44dddddd">
         <main:MainView />
     </dialogs:ReactiveDialogHost>
+    <Window.Styles>
+        <Style Selector="Window[WindowState=Maximized]">
+            <Setter Property="Padding" Value="8" />
+        </Style>
+    </Window.Styles>
 </Window>


### PR DESCRIPTION
Known issue in Avalonia where padding is not respected in fullscreen: https://github.com/AvaloniaUI/Avalonia/issues/5581