### PR TITLE
Add quote parsing for explicit object name search

### DIFF
--- a/Lumidex/Features/Aliases/AliasManagerViewModel.cs
+++ b/Lumidex/Features/Aliases/AliasManagerViewModel.cs
@@ -235,7 +235,7 @@ public partial class AliasManagerViewModel : ValidatableViewModelBase,
     {
         if (SelectedItem?.ObjectName is { } objectName)
         {
-            Messenger.Send(new ObjectNameSearchFill(objectName));
+            Messenger.Send(new ObjectNameSearchFill($"\"{objectName}\""));
             Messenger.Send(new ChangeSideTab(SideNavBarViewModel.SearchTabName));
         }
     }

--- a/Lumidex/Features/MainSearch/Filters/ObjectNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObjectNameFilter.cs
@@ -15,9 +15,10 @@ public partial class ObjectNameFilter : FilterViewModelBase
     {
         if (Name is { Length: > 0 })
         {
-            if (Name.StartsWith("\"") && Name.EndsWith("\""))
+            if (Name.StartsWith('"') && Name.EndsWith('"'))
             {
-                query = query.Where(f => f.ObjectName == Name.Substring(1, Name.Length - 2));
+                var objectName = Name[1..^1];
+                query = query.Where(f => f.ObjectName == objectName);
             }
             else 
             { 

--- a/Lumidex/Features/MainSearch/SearchResultsViewModel.cs
+++ b/Lumidex/Features/MainSearch/SearchResultsViewModel.cs
@@ -281,7 +281,7 @@ public partial class SearchResultsViewModel : ViewModelBase,
     {
         if (objectName is null) return;
 
-        Messenger.Send(new ObjectNameSearchFill(objectName));
+        Messenger.Send(new ObjectNameSearchFill($"\"{objectName}\""));
     }
 
 


### PR DESCRIPTION
- Add quote parsing for explicit object name search, eg. "M 8" no longer returns M 81 as well
- Update send to search features to search with quotes