### PR TITLE
Support boolean OR operator querying filters.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,8 @@
     <PackageVersion Include="Flurl" Version="4.0.0" />
     <PackageVersion Include="Flurl.Http" Version="4.0.2" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="LinqKit" Version="1.3.7" />
+    <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="9.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />

--- a/Lumidex.Tests/Fixtures/DatabaseFixture.cs
+++ b/Lumidex.Tests/Fixtures/DatabaseFixture.cs
@@ -1,0 +1,34 @@
+﻿using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Tests.Fixtures;
+
+public class DatabaseFixture : IDisposable
+{
+    public LumidexDbContext DbContext { get; } = null!;
+
+    public string DatabaseFilename { get; }
+
+    public DatabaseFixture()
+    {
+        var tempFilename = $"lumidex-{Path.GetFileName(Path.GetTempFileName())}.db";
+        DatabaseFilename = Path.Combine(Path.GetTempPath(), "lumidex", tempFilename);
+
+        var builder = new DbContextOptionsBuilder<LumidexDbContext>();
+        builder = builder.UseSqlite($"Data Source={DatabaseFilename}", config => config
+            .UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .EnableSensitiveDataLogging(false);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(DatabaseFilename)!);
+        DbContext = new LumidexDbContext(builder.Options);
+        DbContext.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        DbContext.Database.EnsureDeleted();
+        DbContext.Dispose();
+    }
+}

--- a/Lumidex.Tests/Lumidex.Tests.csproj
+++ b/Lumidex.Tests/Lumidex.Tests.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lumidex.Core\Lumidex.Core.csproj" />
+    <ProjectReference Include="..\Lumidex\Lumidex.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lumidex.Tests/SearchFilterTests.cs
+++ b/Lumidex.Tests/SearchFilterTests.cs
@@ -1,0 +1,121 @@
+﻿using Lumidex.Tests.Fixtures;
+using Lumidex.Features.MainSearch.Filters;
+
+namespace Lumidex.Tests;
+public class SearchFilterTests : IClassFixture<DatabaseFixture>
+{
+    public DatabaseFixture Fixture { get; }
+
+    public SearchFilterTests(DatabaseFixture fixture)
+    {
+        Fixture = fixture;
+        SeedDatabase();
+    }
+
+    private void SeedDatabase()
+    {
+        var dbContext = Fixture.DbContext;
+
+        var library = new Core.Data.Library
+        {
+            Name = "default",
+            Path = @"/tmp",
+        };
+
+        dbContext.Libraries.Add(library);
+
+        dbContext.ImageFiles.AddRange([
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "L",
+                Path = @"/tmp/image-L.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "R",
+                Path = @"/tmp/image-R.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "G",
+                Path = @"/tmp/image-G.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "B",
+                Path = @"/tmp/image-B.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "Ha",
+                Path = @"/tmp/image-Ha.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "Sii",
+                Path = @"/tmp/image-Sii.fits",
+            },
+            new Core.Data.ImageFile
+            {
+                HeaderHash = Guid.NewGuid().ToString(),
+                Library = library,
+                FilterName = "Oiii",
+                Path = @"/tmp/image-Oiii.fits",
+            },
+        ]);
+
+        dbContext.SaveChanges();
+    }
+
+    [Theory]
+    [InlineData("Ha")]
+    [InlineData("ha")]
+    [InlineData("HA")]
+    public void Filter_Simple(string filterContent)
+    {
+        var filter = new FilterFilter { Filter = filterContent };
+        var query = Fixture.DbContext.ImageFiles.AsQueryable();
+        query = filter.ApplyFilter(Fixture.DbContext, query);
+
+        var matches = query.ToList();
+        
+        matches
+            .Select(x => x.FilterName)
+            .Should()
+            .NotBeEmpty()
+            .And
+            .AllBe("Ha");
+    }
+
+    [Theory]
+    [InlineData("ha|sii|oiii")]
+    [InlineData("Ha|Sii|Oiii")]
+    [InlineData("HA|SII|OIII")]
+    public void Filter_BooleanOr(string filterContent)
+    {
+        var filter = new FilterFilter { Filter = filterContent };
+        var query = Fixture.DbContext.ImageFiles.AsQueryable();
+        query = filter.ApplyFilter(Fixture.DbContext, query);
+
+        var matches = query.ToList();
+
+        matches
+            .Select(x => x.FilterName)
+            .Should()
+            .NotBeEmpty()
+            .And
+            .OnlyContain(s => s == "Ha" || s == "Sii" || s == "Oiii");
+    }
+}

--- a/Lumidex/Features/MainSearch/Filters/FilterFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FilterFilter.cs
@@ -1,3 +1,4 @@
+using LinqKit;
 using Lumidex.Core.Data;
 
 namespace Lumidex.Features.MainSearch.Filters;
@@ -14,7 +15,23 @@ public partial class FilterFilter : FilterViewModelBase
     {
         if (Filter is { Length: > 0 } filter)
         {
-            query = query.Where(f => f.FilterName == filter);
+            var items = filter.Split('|');
+            if (items.Length > 0)
+            {
+                var predicate = PredicateBuilder.New<ImageFile>();
+
+                foreach (var item in items)
+                {
+                    string temp = item;
+                    predicate.Or(f => f.FilterName == temp);
+                }
+
+                query = query.Where(predicate);
+            }
+            else
+            {
+                query = query.Where(f => f.FilterName == filter);
+            }
         }
 
         return query;

--- a/Lumidex/Lumidex.csproj
+++ b/Lumidex/Lumidex.csproj
@@ -35,6 +35,8 @@
     <PackageReference Include="Flurl" />
     <PackageReference Include="Flurl.Http" />
     <PackageReference Include="Humanizer" />
+    <PackageReference Include="LinqKit" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="ObservableCollectionEx" />
     <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" />


### PR DESCRIPTION
Use the "|" character to perform boolean ORs for queries containing a filter name. E.g. you can search for images that were shot with the R, G, or B filter by searching for "R|G|B". The query text is case insensitive.

Resolves #79.