### PR TITLE
Remember the search filters used by the user.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,9 +11,9 @@
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.2.0" />
-    <PackageVersion Include="Avalonia.Xaml.Interactivity" Version="11.2.0" />
-    <PackageVersion Include="AvaloniaDialogs" Version="3.6.0" />
+    <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.2.0.1" />
+    <PackageVersion Include="Avalonia.Xaml.Interactivity" Version="11.2.0.1" />
+    <PackageVersion Include="AvaloniaDialogs" Version="3.6.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.8.1" />
     <PackageVersion Include="FluentResults" Version="3.16.0" />
@@ -27,27 +27,27 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="ObservableCollectionEx" Version="1.4.57" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.4.1" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.4.1" />
-    <PackageVersion Include="Serilog" Version="4.1.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.5.0" />
+    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.5.0" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="21.1.3" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="21.1.7" />
     <!-- Development Tools -->
-    <PackageVersion Include="HotAvalonia" Version="2.0.1" />
-    <PackageVersion Include="HotAvalonia.Extensions" Version="2.0.1" />
+    <PackageVersion Include="HotAvalonia" Version="2.0.2" />
+    <PackageVersion Include="HotAvalonia.Extensions" Version="2.0.2" />
     <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="GitVersion.MsBuild" Version="6.0.5" />
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.1.0" />
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="21.1.3" />
+    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.analyzers" Version="1.17.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Lumidex.Core/Data/AppSettings.cs
+++ b/Lumidex.Core/Data/AppSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
 
 namespace Lumidex.Core.Data;
 
@@ -6,5 +6,9 @@ public class AppSettings
 {
     public int Id { get; set; }
 
-    public ICollection<AstrobinFilter> AstrobinFilters { get; set; } = new List<AstrobinFilter>();
+    public bool PersistFiltersOnExit { get; set; } = true;
+
+    public ICollection<AstrobinFilter> AstrobinFilters { get; set; } = [];
+
+    public ICollection<PersistedFilter> PersistedFilters { get; set; } = [];
 }

--- a/Lumidex.Core/Data/AstrobinFilter.cs
+++ b/Lumidex.Core/Data/AstrobinFilter.cs
@@ -5,7 +5,11 @@ namespace Lumidex.Core.Data;
 public class AstrobinFilter
 {
     public int Id { get; set; }
-    
+
+    public int AppSettingsId { get; set; }
+
+    public AppSettings AppSettings { get; set; } = null!;
+
     public int AstrobinId { get; set; }
 
     [Column(TypeName = "TEXT COLLATE NOCASE")]

--- a/Lumidex.Core/Data/LumidexDbContext.cs
+++ b/Lumidex.Core/Data/LumidexDbContext.cs
@@ -26,6 +26,7 @@ public class LumidexDbContext : DbContext
     public DbSet<ImageFile> ImageFiles { get; set; }
     public DbSet<ObjectAlias> ObjectAliases { get; set; }
     public DbSet<AstrobinFilter> AstrobinFilters { get; set; }
+    public DbSet<PersistedFilter> PersistedFilters { get; set; }
 
     public LumidexDbContext(DbContextOptions<LumidexDbContext> options)
         : base(options)
@@ -49,7 +50,10 @@ public class LumidexDbContext : DbContext
         modelBuilder.Entity<Tag>()
             .Property(x => x.Color)
             .HasDefaultValue("#ffffffff");
-            
+
+        modelBuilder.Entity<AppSettings>()
+            .Property(x => x.PersistFiltersOnExit)
+            .HasDefaultValue(true);
     }
 
     public override int SaveChanges()

--- a/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.Designer.cs
+++ b/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumidex.Core.Data.Migrations
 {
     [DbContext(typeof(LumidexDbContext))]
-    partial class LumidexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241212070420_PersistFilters")]
+    partial class PersistFilters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.cs
+++ b/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.cs
@@ -10,6 +10,10 @@ namespace Lumidex.Core.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Earlier versions were not setting AppSettingsId so its value in the db is null.
+            // There is only one AppSettings row so force the values to 1.
+            migrationBuilder.Sql(@"UPDATE AstrobinFilters SET AppSettingsId = '1' WHERE AppSettingsId IS NULL;");
+
             migrationBuilder.DropForeignKey(
                 name: "FK_AstrobinFilters_AppSettings_AppSettingsId",
                 table: "AstrobinFilters");

--- a/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.cs
+++ b/Lumidex.Core/Data/Migrations/20241212070420_PersistFilters.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumidex.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersistFilters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AstrobinFilters_AppSettings_AppSettingsId",
+                table: "AstrobinFilters");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AppSettingsId",
+                table: "AstrobinFilters",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PersistFiltersOnExit",
+                table: "AppSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.CreateTable(
+                name: "PersistedFilters",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    AppSettingsId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Data = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersistedFilters", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PersistedFilters_AppSettings_AppSettingsId",
+                        column: x => x.AppSettingsId,
+                        principalTable: "AppSettings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersistedFilters_AppSettingsId",
+                table: "PersistedFilters",
+                column: "AppSettingsId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AstrobinFilters_AppSettings_AppSettingsId",
+                table: "AstrobinFilters",
+                column: "AppSettingsId",
+                principalTable: "AppSettings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AstrobinFilters_AppSettings_AppSettingsId",
+                table: "AstrobinFilters");
+
+            migrationBuilder.DropTable(
+                name: "PersistedFilters");
+
+            migrationBuilder.DropColumn(
+                name: "PersistFiltersOnExit",
+                table: "AppSettings");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AppSettingsId",
+                table: "AstrobinFilters",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AstrobinFilters_AppSettings_AppSettingsId",
+                table: "AstrobinFilters",
+                column: "AppSettingsId",
+                principalTable: "AppSettings",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Lumidex.Core/Data/PersistedFilter.cs
+++ b/Lumidex.Core/Data/PersistedFilter.cs
@@ -1,0 +1,14 @@
+﻿namespace Lumidex.Core.Data;
+
+public class PersistedFilter
+{
+    public int Id { get; set; }
+
+    public int AppSettingsId { get; set; }
+
+    public AppSettings AppSettings { get; set; } = null!;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Data { get; set; }
+}

--- a/Lumidex/Bootstrapper.cs
+++ b/Lumidex/Bootstrapper.cs
@@ -24,6 +24,15 @@ public static class Bootstrapper
 
     public static void Stop()
     {
+        try
+        {
+            WeakReferenceMessenger.Default.Send(new ExitingMessage());
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Error while stopping Lumidex");
+        }
+
         Log.Information("Lumidex exiting, bye");
         (Services as ServiceProvider)?.Dispose();
         Core.Bootstrapper.Stop();

--- a/Lumidex/ExitingMessage.cs
+++ b/Lumidex/ExitingMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace Lumidex;
+
+public class ExitingMessage { }

--- a/Lumidex/Features/MainSearch/Filters/AirmassFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/AirmassFilter.cs
@@ -32,5 +32,47 @@ public partial class AirmassFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Airmass",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Airmass")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/AltitudeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/AltitudeFilter.cs
@@ -32,5 +32,47 @@ public partial class AltitudeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Altitude",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Altitude")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/AzimuthFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/AzimuthFilter.cs
@@ -40,5 +40,47 @@ public partial class AzimuthFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Azimuth",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Azimuth")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraBinningFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraBinningFilter.cs
@@ -32,5 +32,47 @@ public partial class CameraBinningFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "CameraBinning",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "CameraBinning")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraGainFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraGainFilter.cs
@@ -32,5 +32,47 @@ public partial class CameraGainFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "CameraGain",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "CameraGain")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraNameFilter.cs
@@ -21,5 +21,24 @@ public partial class CameraNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "CameraName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "CameraName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraOffsetFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraOffsetFilter.cs
@@ -32,5 +32,47 @@ public partial class CameraOffsetFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "CameraOffset",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "CameraOffset")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraTemperatureFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraTemperatureFilter.cs
@@ -32,5 +32,47 @@ public partial class CameraTemperatureFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "CameraTemperature",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "CameraTemperature")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/CameraTemperatureSetPointFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/CameraTemperatureSetPointFilter.cs
@@ -32,5 +32,47 @@ public partial class CameraTemperatureSetPointFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "CameraTemperatureSetpoint",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "CameraTemperatureSetpoint")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/DeclinationFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/DeclinationFilter.cs
@@ -32,5 +32,47 @@ public partial class DeclinationFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Declination",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Declination")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/DewPointFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/DewPointFilter.cs
@@ -32,5 +32,47 @@ public partial class DewPointFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "DewPoint",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "DewPoint")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/ElevationFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ElevationFilter.cs
@@ -32,5 +32,47 @@ public partial class ElevationFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Elevation",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Elevation")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/ExposureFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ExposureFilter.cs
@@ -32,5 +32,47 @@ public partial class ExposureFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (ExposureMin is null && ExposureMax is null)
+            return null;
+
+        var min = ExposureMin.HasValue ? ExposureMin.Value.ToString() : string.Empty;
+        var max = ExposureMax.HasValue ? ExposureMax.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Exposure",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Exposure")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    ExposureMin = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    ExposureMax = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({ExposureMin}, {ExposureMax})";
 }

--- a/Lumidex/Features/MainSearch/Filters/FilterFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FilterFilter.cs
@@ -37,5 +37,24 @@ public partial class FilterFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Filter is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "Filter",
+            Data = Filter,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "Filter")
+        {
+            Filter = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Filter}";
 }

--- a/Lumidex/Features/MainSearch/Filters/FilterViewModelBase.cs
+++ b/Lumidex/Features/MainSearch/Filters/FilterViewModelBase.cs
@@ -14,4 +14,8 @@ public abstract partial class FilterViewModelBase : ValidatableViewModelBase
     }
 
     protected virtual void OnClear() { }
+
+    public virtual PersistedFilter? Persist() => null;
+
+    public virtual bool Restore(PersistedFilter persistedFilter) => false;
 }

--- a/Lumidex/Features/MainSearch/Filters/FilterWheelNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FilterWheelNameFilter.cs
@@ -21,5 +21,24 @@ public partial class FilterWheelNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "FilterWheelName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "FilterWheelName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/FocalLengthFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FocalLengthFilter.cs
@@ -32,5 +32,47 @@ public partial class FocalLengthFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "FocalLength",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "FocalLength")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/FocuserNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FocuserNameFilter.cs
@@ -21,5 +21,24 @@ public partial class FocuserNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "FocuserName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "FocuserName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/FocuserPositionFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FocuserPositionFilter.cs
@@ -32,5 +32,47 @@ public partial class FocuserPositionFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "FocuserPosition",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "FocuserPosition")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/FocuserTemperatureFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/FocuserTemperatureFilter.cs
@@ -32,5 +32,47 @@ public partial class FocuserTemperatureFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "FocuserTemperature",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "FocuserTemperature")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/HumidityFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/HumidityFilter.cs
@@ -32,5 +32,47 @@ public partial class HumidityFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Humidity",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Humidity")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/ImageKindFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ImageKindFilter.cs
@@ -22,5 +22,25 @@ public partial class ImageKindFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => ImageKind is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ImageKind",
+            Data = ImageKind.ToString(),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ImageKind" &&
+            Enum.TryParse<ImageKind>(persistedFilter.Data, out var imageKind))
+        {
+            ImageKind = imageKind;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {ImageKind}";
 }

--- a/Lumidex/Features/MainSearch/Filters/ImageTypeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ImageTypeFilter.cs
@@ -22,5 +22,25 @@ public partial class ImageTypeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => ImageType is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ImageType",
+            Data = ImageType.ToString(),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ImageType" &&
+            Enum.TryParse<ImageType>(persistedFilter.Data, out var imageType))
+        {
+            ImageType = imageType;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {ImageType}";
 }

--- a/Lumidex/Features/MainSearch/Filters/LatitudeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/LatitudeFilter.cs
@@ -32,5 +32,47 @@ public partial class LatitudeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Latitude",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Latitude")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/LongitudeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/LongitudeFilter.cs
@@ -32,5 +32,47 @@ public partial class LongitudeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Longitude",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Longitude")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/ObjectNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObjectNameFilter.cs
@@ -44,5 +44,24 @@ public partial class ObjectNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ObjectName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ObjectName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/ObservationBeginLocalFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObservationBeginLocalFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lumidex.Core.Data;
+using System.Globalization;
 
 namespace Lumidex.Features.MainSearch.Filters;
 
@@ -18,6 +19,26 @@ public partial class ObservationBeginLocalFilter : FilterViewModelBase
         }
 
         return query;
+    }
+
+    public override PersistedFilter? Persist() => DateBegin is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ObservationBeginLocal",
+            Data = DateBegin.Value.ToString("o"),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ObservationBeginLocal" &&
+            DateTime.TryParseExact(persistedFilter.Data, "o", null, DateTimeStyles.None, out var datetime))
+        {
+            DateBegin = datetime;
+            return true;
+        }
+
+        return false;
     }
 
     public override string ToString() => $"{DisplayName} = {DateBegin}";

--- a/Lumidex/Features/MainSearch/Filters/ObservationBeginUtcFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObservationBeginUtcFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lumidex.Core.Data;
+using System.Globalization;
 
 namespace Lumidex.Features.MainSearch.Filters;
 
@@ -18,6 +19,26 @@ public partial class ObservationBeginUtcFilter : FilterViewModelBase
         }
 
         return query;
+    }
+
+    public override PersistedFilter? Persist() => DateBegin is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ObservationBeginUtc",
+            Data = DateBegin.Value.ToString("o"),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ObservationBeginUtc" &&
+            DateTime.TryParseExact(persistedFilter.Data, "o", null, DateTimeStyles.None, out var datetime))
+        {
+            DateBegin = datetime;
+            return true;
+        }
+
+        return false;
     }
 
     public override string ToString() => $"{DisplayName} = {DateBegin}";

--- a/Lumidex/Features/MainSearch/Filters/ObservationEndLocalFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObservationEndLocalFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lumidex.Core.Data;
+using System.Globalization;
 
 namespace Lumidex.Features.MainSearch.Filters;
 
@@ -21,6 +22,26 @@ public partial class ObservationEndLocalFilter : FilterViewModelBase
         }
 
         return query;
+    }
+
+    public override PersistedFilter? Persist() => DateEnd is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ObservationEndLocal",
+            Data = DateEnd.Value.ToString("o"),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ObservationEndLocal" &&
+            DateTime.TryParseExact(persistedFilter.Data, "o", null, DateTimeStyles.None, out var datetime))
+        {
+            DateEnd = datetime;
+            return true;
+        }
+
+        return false;
     }
 
     public override string ToString() => $"{DisplayName} = {DateEnd}";

--- a/Lumidex/Features/MainSearch/Filters/ObservationEndUtcFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ObservationEndUtcFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lumidex.Core.Data;
+using System.Globalization;
 
 namespace Lumidex.Features.MainSearch.Filters;
 
@@ -21,6 +22,26 @@ public partial class ObservationEndUtcFilter : FilterViewModelBase
         }
 
         return query;
+    }
+
+    public override PersistedFilter? Persist() => DateEnd is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ObservationEndUtc",
+            Data = DateEnd.Value.ToString("o"),
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ObservationEndUtc" &&
+            DateTime.TryParseExact(persistedFilter.Data, "o", null, DateTimeStyles.None, out var datetime))
+        {
+            DateEnd = datetime;
+            return true;
+        }
+
+        return false;
     }
 
     public override string ToString() => $"{DisplayName} = {DateEnd}";

--- a/Lumidex/Features/MainSearch/Filters/PathFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/PathFilter.cs
@@ -21,5 +21,24 @@ public partial class PathFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "Path",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "Path")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/PixelSizeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/PixelSizeFilter.cs
@@ -32,5 +32,47 @@ public partial class PixelSizeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "PixelSize",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "PixelSize")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/PressureFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/PressureFilter.cs
@@ -32,5 +32,47 @@ public partial class PressureFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Pressure",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Pressure")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/ReadoutModeFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/ReadoutModeFilter.cs
@@ -21,5 +21,24 @@ public partial class ReadoutModeFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "ReadoutMode",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "ReadoutMode")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/RightAscensionFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/RightAscensionFilter.cs
@@ -34,5 +34,47 @@ public partial class RightAscensionFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "RightAscension",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "RightAscension")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/RotatorNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/RotatorNameFilter.cs
@@ -21,5 +21,24 @@ public partial class RotatorNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "RotatorName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "RotatorName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/RotatorPositionFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/RotatorPositionFilter.cs
@@ -40,5 +40,47 @@ public partial class RotatorPositionFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "RotatorPosition",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "RotatorPosition")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/Filters/TelescopeNameFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/TelescopeNameFilter.cs
@@ -21,5 +21,24 @@ public partial class TelescopeNameFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist() => Name is null
+        ? null
+        : new PersistedFilter
+        {
+            Name = "TelescopeName",
+            Data = Name,
+        };
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        if (persistedFilter.Name == "TelescopeName")
+        {
+            Name = persistedFilter.Data;
+            return true;
+        }
+
+        return false;
+    }
+
     public override string ToString() => $"{DisplayName} = {Name}";
 }

--- a/Lumidex/Features/MainSearch/Filters/TemperatureFilter.cs
+++ b/Lumidex/Features/MainSearch/Filters/TemperatureFilter.cs
@@ -32,5 +32,47 @@ public partial class TemperatureFilter : FilterViewModelBase
         return query;
     }
 
+    public override PersistedFilter? Persist()
+    {
+        if (MinValue is null && MaxValue is null)
+            return null;
+
+        var min = MinValue.HasValue ? MinValue.Value.ToString() : string.Empty;
+        var max = MaxValue.HasValue ? MaxValue.Value.ToString() : string.Empty;
+
+        return new PersistedFilter
+        {
+            Name = "Temperature",
+            Data = $"{min}|{max}"
+        };
+    }
+
+    public override bool Restore(PersistedFilter persistedFilter)
+    {
+        var restored = false;
+
+        if (persistedFilter.Name == "Temperature")
+        {
+            var data = persistedFilter.Data ?? string.Empty;
+            var split = data.Split('|', count: 2);
+            if (split.Length == 2)
+            {
+                if (decimal.TryParse(split[0], out var min))
+                {
+                    MinValue = min;
+                    restored = true;
+                }
+
+                if (decimal.TryParse(split[1], out var max))
+                {
+                    MaxValue = max;
+                    restored = true;
+                }
+            }
+        }
+
+        return restored;
+    }
+
     public override string ToString() => $"{DisplayName} = ({MinValue}, {MaxValue})";
 }

--- a/Lumidex/Features/MainSearch/SearchQueryView.axaml
+++ b/Lumidex/Features/MainSearch/SearchQueryView.axaml
@@ -90,7 +90,7 @@
                 <ComboBox
                     x:Name="AdvancedFilterComboBox"
                     HorizontalAlignment="Stretch"
-                    ItemsSource="{Binding AllFilters}"
+                    ItemsSource="{Binding AvailableFilters}"
                     PlaceholderForeground="Gray"
                     PlaceholderText="Select a Filter">
                     <ComboBox.ItemTemplate>

--- a/Lumidex/Features/Settings/AstrobinSettingsViewModel.cs
+++ b/Lumidex/Features/Settings/AstrobinSettingsViewModel.cs
@@ -94,6 +94,7 @@ public partial class AstrobinSettingsViewModel : ViewModelBase, ISettingsViewMod
         {
             AstrobinId = astrobinFilter.Id,
             Name = astrobinFilter.Name,
+            AppSettings = dbContext.AppSettings.First(),
         };
 
         dbContext.AstrobinFilters.Add(filter);

--- a/Lumidex/Features/Settings/MainSettingsView.axaml
+++ b/Lumidex/Features/Settings/MainSettingsView.axaml
@@ -22,7 +22,7 @@
 
         <ContentControl
             Grid.Column="1"
-            Margin="8"
+            Margin="8,0,8,8"
             Content="{Binding SelectedViewModel}" />
 
     </Grid>

--- a/Lumidex/Features/Settings/MainSettingsViewModel.cs
+++ b/Lumidex/Features/Settings/MainSettingsViewModel.cs
@@ -7,10 +7,12 @@ public partial class MainSettingsViewModel : ViewModelBase
     public ObservableCollectionEx<ISettingsViewModel> ViewModels { get; }
 
     public MainSettingsViewModel(
-        AstrobinSettingsViewModel astrobinSettings)
+        AstrobinSettingsViewModel astrobinSettings,
+        SearchSettingsViewModel searchSettings)
     {
         ViewModels = [
             astrobinSettings,
+            searchSettings,
         ];
 
         SelectedViewModel = astrobinSettings;

--- a/Lumidex/Features/Settings/SearchSettingsView.axaml
+++ b/Lumidex/Features/Settings/SearchSettingsView.axaml
@@ -1,0 +1,30 @@
+<UserControl
+    x:Class="Lumidex.Features.Settings.SearchSettingsView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:common="using:Lumidex.Common"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:exporter="using:Lumidex.Core.Exporters"
+    xmlns:i="https://github.com/projektanker/icons.avalonia"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:settings="using:Lumidex.Features.Settings"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:DataType="settings:SearchSettingsViewModel"
+    mc:Ignorable="d">
+    <Grid ColumnDefinitions="*,*">
+        <StackPanel>
+            <UniformGrid Columns="2">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    DockPanel.Dock="Left"
+                    Text="Save Filters On Exit" />
+                <ToggleSwitch
+                    HorizontalAlignment="Right"
+                    IsChecked="{Binding PersistFiltersOnExit}"
+                    OffContent=""
+                    OnContent="" />
+            </UniformGrid>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Lumidex/Features/Settings/SearchSettingsView.axaml.cs
+++ b/Lumidex/Features/Settings/SearchSettingsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Lumidex.Features.Settings;
+
+public partial class SearchSettingsView : UserControl
+{
+    public SearchSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Lumidex/Features/Settings/SearchSettingsViewModel.cs
+++ b/Lumidex/Features/Settings/SearchSettingsViewModel.cs
@@ -1,0 +1,46 @@
+﻿using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Features.Settings;
+
+public partial class SearchSettingsViewModel : ViewModelBase, ISettingsViewModel
+{
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+
+    [ObservableProperty] bool _persistFiltersOnExit;
+
+    public string DisplayName => "Search";
+
+    public SearchSettingsViewModel(IDbContextFactory<LumidexDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+
+        using var dbContext = _dbContextFactory.CreateDbContext();
+        var settings = dbContext.AppSettings.FirstOrDefault();
+        if (settings is not null)
+        {
+            PersistFiltersOnExit = settings.PersistFiltersOnExit;
+        }
+    }
+
+    partial void OnPersistFiltersOnExitChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue != newValue)
+        {
+            using var dbContext = _dbContextFactory.CreateDbContext();
+            var settings = dbContext.AppSettings.FirstOrDefault();
+            if (settings is not null)
+            {
+                settings.PersistFiltersOnExit = newValue;
+
+                // Clear any persisted filters if the user is turning this feature off.
+                if (newValue == false)
+                {
+                    settings.PersistedFilters.Clear();
+                }
+
+                dbContext.SaveChanges();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When a user searches their data, Lumidex should persist the filters used so the user doesn't have to select the filters again on next startup. Often times the same filters are used and it is annoying having to reselect the same ones every time.

Each filter's parameters are persisted to the database on application shutdown. The parameters are restored on startup.

Resolves #91.