### PR TITLE
Use intermediate kind instead of calibration when the user has select…

### DIFF
--- a/Lumidex.Core/Data/AppSettings.cs
+++ b/Lumidex.Core/Data/AppSettings.cs
@@ -6,7 +6,7 @@ public class AppSettings
 
     public bool PersistFiltersOnExit { get; set; } = true;
 
-    public bool UseCalibratedFrames { get; set; }
+    public bool UseIntermediateFramesForPlots { get; set; }
 
     public ICollection<AstrobinFilter> AstrobinFilters { get; set; } = [];
 

--- a/Lumidex.Core/Data/Migrations/20241223031636_RenameUseCalibratedFrames.Designer.cs
+++ b/Lumidex.Core/Data/Migrations/20241223031636_RenameUseCalibratedFrames.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumidex.Core.Data.Migrations
 {
     [DbContext(typeof(LumidexDbContext))]
-    partial class LumidexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241223031636_RenameUseCalibratedFrames")]
+    partial class RenameUseCalibratedFrames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/Lumidex.Core/Data/Migrations/20241223031636_RenameUseCalibratedFrames.cs
+++ b/Lumidex.Core/Data/Migrations/20241223031636_RenameUseCalibratedFrames.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumidex.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameUseCalibratedFrames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "UseCalibratedFrames",
+                table: "AppSettings",
+                newName: "UseIntermediateFramesForPlots");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "UseIntermediateFramesForPlots",
+                table: "AppSettings",
+                newName: "UseCalibratedFrames");
+        }
+    }
+}

--- a/Lumidex/Features/Plot/IntegrationHeatmapViewModel.cs
+++ b/Lumidex/Features/Plot/IntegrationHeatmapViewModel.cs
@@ -216,9 +216,9 @@ public partial class IntegrationHeatmapViewModel : PlotViewModel
         var settings = dbContext.AppSettings.FirstOrDefault();
         if (settings is not null)
         {
-            if (settings.UseCalibratedFrames)
+            if (settings.UseIntermediateFramesForPlots)
             {
-                kind = (int)ImageKind.Calibration;
+                kind = (int)ImageKind.Intermediate;
             }
         }
 

--- a/Lumidex/Features/Plot/IntegrationOverTimeViewModel.cs
+++ b/Lumidex/Features/Plot/IntegrationOverTimeViewModel.cs
@@ -110,9 +110,9 @@ public partial class IntegrationOverTimeViewModel : PlotViewModel
         var settings = dbContext.AppSettings.FirstOrDefault();
         if (settings is not null)
         {
-            if (settings.UseCalibratedFrames)
+            if (settings.UseIntermediateFramesForPlots)
             {
-                kind = (int)ImageKind.Calibration;
+                kind = (int)ImageKind.Intermediate;
             }
         }
 

--- a/Lumidex/Features/Plot/IntegrationPiePlotViewModel.cs
+++ b/Lumidex/Features/Plot/IntegrationPiePlotViewModel.cs
@@ -158,9 +158,9 @@ public partial class IntegrationPiePlotViewModel : PlotViewModel
         var settings = dbContext.AppSettings.FirstOrDefault();
         if (settings is not null)
         {
-            if (settings.UseCalibratedFrames)
+            if (settings.UseIntermediateFramesForPlots)
             {
-                kind = ImageKind.Calibration;
+                kind = ImageKind.Intermediate;
             }
         }
 

--- a/Lumidex/Features/Settings/PlotSettingsView.axaml
+++ b/Lumidex/Features/Settings/PlotSettingsView.axaml
@@ -18,10 +18,10 @@
                 <TextBlock
                     VerticalAlignment="Center"
                     DockPanel.Dock="Left"
-                    Text="Use Calibrated Frames Instead of Raw" />
+                    Text="Use Intermediate Frames Instead of Raw" />
                 <ToggleSwitch
                     HorizontalAlignment="Right"
-                    IsChecked="{Binding UseCalibratedFrames}"
+                    IsChecked="{Binding UseIntermediateFrames}"
                     OffContent=""
                     OnContent="" />
             </UniformGrid>

--- a/Lumidex/Features/Settings/PlotSettingsViewModel.cs
+++ b/Lumidex/Features/Settings/PlotSettingsViewModel.cs
@@ -10,7 +10,7 @@ public partial class PlotSettingsViewModel : ViewModelBase, ISettingsViewModel
     public string DisplayName => "Plot";
 
     [ObservableProperty]
-    public partial bool UseCalibratedFrames { get; set; }
+    public partial bool UseIntermediateFrames { get; set; }
 
     public PlotSettingsViewModel(IDbContextFactory<LumidexDbContext> dbContextFactory)
     {
@@ -20,11 +20,11 @@ public partial class PlotSettingsViewModel : ViewModelBase, ISettingsViewModel
         var settings = dbContext.AppSettings.FirstOrDefault();
         if (settings is not null)
         {
-            UseCalibratedFrames = settings.UseCalibratedFrames;
+            UseIntermediateFrames = settings.UseIntermediateFramesForPlots;
         }
     }
 
-    partial void OnUseCalibratedFramesChanged(bool oldValue, bool newValue)
+    partial void OnUseIntermediateFramesChanged(bool oldValue, bool newValue)
     {
         if (oldValue != newValue)
         {
@@ -32,7 +32,7 @@ public partial class PlotSettingsViewModel : ViewModelBase, ISettingsViewModel
             var settings = dbContext.AppSettings.FirstOrDefault();
             if (settings is not null)
             {
-                settings.UseCalibratedFrames = newValue;
+                settings.UseIntermediateFramesForPlots = newValue;
                 dbContext.SaveChanges();
             }
         }


### PR DESCRIPTION
…ed to use intermediate images for plots instead of raws.