### PR TITLE
Added Siril Image Kind detection

### DIFF
--- a/Lumidex.Core/Detection/HeaderReader.cs
+++ b/Lumidex.Core/Detection/HeaderReader.cs
@@ -151,6 +151,46 @@ public class HeaderReader
                 return ImageKind.Intermediate;
         }
 
+        if (header.GetEntry<string>("PROGRAM") is { Value: { } } programEntry)
+        {
+            //Siril always adds the PROGRAM header with the value "Siril <version number>"
+            if (programEntry.Value.AsSpan().Contains("Siril", StringComparison.OrdinalIgnoreCase))
+            {
+
+                if (header.GetEntry<int>("STACKCNT") is { Value: { } } stackCountEntry)
+                {
+                    //Siril always adds this header for stacked images,
+                    //So must be either a Master or Intermediate image.
+                    //Siril does not add headers that identify whether the image is Flat, Dark, or Bias
+                    //This info must come from capture software.
+
+                    switch (imageType)
+                    {
+                        case ImageType.Flat:
+                        case ImageType.Dark:
+                        case ImageType.Bias:
+                            return ImageKind.Master;
+                        case ImageType.Light:
+                        case ImageType.Unknown:
+                            return ImageKind.Intermediate;
+                    }
+                }
+
+                //Not stacked so either a Calibration or Intermediate image.
+                switch (imageType)
+                {
+                    case ImageType.Flat:
+                    case ImageType.Dark:
+                    case ImageType.Bias:
+                        return ImageKind.Calibration;
+                    case ImageType.Light:
+                    case ImageType.Unknown:
+                        return ImageKind.Intermediate;
+                }
+
+            }
+        }
+
         if (isIntermediate == false &&
             hasBeenIntegrated == false)
         {


### PR DESCRIPTION
Added detection of Image Kind based on FITS headers "PROGRAM" that identifies a file as being written by Siril and "STACKCNT" that identifies a file being a stack of several images.

Assumptions made:

- If a file is written by Siril then it is not a Raw image any more. Arguments could be made that "only doing X with Siril and saving" should still count as a Raw - but this would be a slippery slope making it impossible to draw any boundary
- Flat/Bias/Dark detection is based purely on existing logic - but since Siril does not add any headers for different types of images the assumption is that capture software has done it. For example people using DSLR cameras will end up with all Intermediate images since the ImageType will always be Unknown