### PR TITLE
Scope library ingest dedup query to the scanning library's rows.

### DIFF
--- a/Lumidex.Core/Pipelines/LibraryIngestPipeline.cs
+++ b/Lumidex.Core/Pipelines/LibraryIngestPipeline.cs
@@ -230,8 +230,20 @@ public class LibraryIngestPipeline
                 var updateStatuses = new List<IngestStatus>(messages.Length);
                 var skipStatuses = new List<IngestStatus>(messages.Length);
                 var hashes = fileInfoLookup.Keys.ToHashSet();
+
+                // Scope dedup to the library currently being scanned. A hash
+                // match in another library is not a duplicate from this
+                // library's perspective — libraries are logically independent,
+                // and the same physical file may legitimately exist in more
+                // than one. All messages in a single pipeline invocation come
+                // from the same library today; Distinct().Single() locks
+                // that invariant so any future refactor that mixed libraries
+                // into one batch would fault loudly into ProcessAsync's
+                // top-level catch rather than silently mis-scoping and
+                // reintroducing #66.
+                var libraryId = messages.Select(m => m.Value.LibraryId).Distinct().Single();
                 var imageFiles = dbContext.ImageFiles
-                    .Where(f => hashes.Contains(f.HeaderHash))
+                    .Where(f => f.LibraryId == libraryId && hashes.Contains(f.HeaderHash))
                     .ToList();
 
                 foreach (var imageFile in imageFiles)

--- a/Lumidex.Tests/Fixtures/TestDbContextFactory.cs
+++ b/Lumidex.Tests/Fixtures/TestDbContextFactory.cs
@@ -1,0 +1,19 @@
+using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Tests.Fixtures;
+
+// Test-only IDbContextFactory that creates fresh LumidexDbContext instances
+// pointing at the SQLite file owned by DatabaseFixture. LibraryIngestPipeline
+// needs a factory (rather than a shared DbContext) so each pipeline stage can
+// use its own short-lived context without cross-thread EF state interference.
+internal sealed class TestDbContextFactory(string databaseFilename)
+    : IDbContextFactory<LumidexDbContext>
+{
+    private readonly DbContextOptions<LumidexDbContext> _options =
+        new DbContextOptionsBuilder<LumidexDbContext>()
+            .UseSqlite($"Data Source={databaseFilename}")
+            .Options;
+
+    public LumidexDbContext CreateDbContext() => new LumidexDbContext(_options);
+}

--- a/Lumidex.Tests/LibraryIngestPipelineTests.cs
+++ b/Lumidex.Tests/LibraryIngestPipelineTests.cs
@@ -1,0 +1,89 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Pipelines;
+using Microsoft.EntityFrameworkCore;
+using System.IO.Abstractions;
+using Lumidex.Tests.Fixtures;
+
+namespace Lumidex.Tests;
+
+public class LibraryIngestPipelineTests : IClassFixture<DatabaseFixture>
+{
+    private readonly DatabaseFixture _dbFixture;
+    private readonly IFileSystem _fileSystem = new FileSystem();
+    private readonly IDbContextFactory<LumidexDbContext> _contextFactory;
+
+    public LibraryIngestPipelineTests(DatabaseFixture dbFixture)
+    {
+        _dbFixture = dbFixture;
+        _contextFactory = new TestDbContextFactory(dbFixture.DatabaseFilename);
+    }
+
+    // Regression test for the cross-library dedup bug in upstream issue #66.
+    //
+    // Reporter scenario: the same physical XISF file was placed in two
+    // separate library folders. Scanning the second library produced a
+    // confusing "1 Added, 1 Skipped" status — which looks like something
+    // went wrong even though the file was, in fact, correctly added to
+    // the second library.
+    //
+    // Root cause: block3GetOrCreateEntity's dedup query searched ImageFiles
+    // across ALL libraries by HeaderHash. When the second library was
+    // scanned, the query matched the row the first library had created,
+    // emitted a spurious "Skipped" status, then still added a fresh row
+    // to the second library because the (hash, path) pair didn't match.
+    //
+    // Fix: scope the dedup query to the library currently being scanned.
+    // Libraries are logically independent; a hash match in another
+    // library isn't a duplicate from the scanning library's perspective.
+    [Fact]
+    public async Task SameFileInTwoLibraries_SecondLibraryScan_DoesNotEmitMisleadingSkipped()
+    {
+        using var xisf = new XisfFixture();
+        var generated = xisf.GenerateXisfFile(
+            new XisfHeaderContent("OBJECT", "Test-Target"),
+            new XisfHeaderContent("EXPOSURE", "60.0"));
+
+        var lib1Dir = Path.Combine(Path.GetTempPath(), $"lumidex-test-lib1-{Guid.NewGuid():N}");
+        var lib2Dir = Path.Combine(Path.GetTempPath(), $"lumidex-test-lib2-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(lib1Dir);
+        Directory.CreateDirectory(lib2Dir);
+
+        try
+        {
+            File.Copy(generated.FullName, Path.Combine(lib1Dir, "shared.xisf"));
+            File.Copy(generated.FullName, Path.Combine(lib2Dir, "shared.xisf"));
+
+            var library1 = new Library { Name = "Lib1", Path = lib1Dir };
+            var library2 = new Library { Name = "Lib2", Path = lib2Dir };
+            _dbFixture.DbContext.Libraries.AddRange(library1, library2);
+            _dbFixture.DbContext.SaveChanges();
+
+            var pipeline = new LibraryIngestPipeline(_fileSystem, _contextFactory);
+
+            // First library — fresh DB, should add cleanly with no skips.
+            await pipeline.ProcessAsync(library1, forceFullScan: true);
+            pipeline.Added.Count.Should().Be(1);
+            pipeline.Skipped.Count.Should().Be(0);
+
+            // Second library — this is the bug scenario. The fix should produce
+            // a clean "1 Added, 0 Skipped" because the dedup now scopes to
+            // library2's rows only, and library2 has no matching hash yet.
+            await pipeline.ProcessAsync(library2, forceFullScan: true);
+            pipeline.Added.Count.Should().Be(1);
+            pipeline.Skipped.Count.Should().Be(0,
+                "upstream #66: the pre-fix behavior reported 1 Skipped here because the "
+                + "dedup query matched library1's row across library boundaries");
+
+            // Both libraries should own their own independent row.
+            using var verify = _contextFactory.CreateDbContext();
+            var files = verify.ImageFiles.ToList();
+            files.Should().HaveCount(2);
+            files.Select(f => f.LibraryId).Should().BeEquivalentTo(new[] { library1.Id, library2.Id });
+        }
+        finally
+        {
+            if (Directory.Exists(lib1Dir)) Directory.Delete(lib1Dir, recursive: true);
+            if (Directory.Exists(lib2Dir)) Directory.Delete(lib2Dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the spurious "Skipped" messaging half of #66. When the same physical file existed in two separate libraries, scanning the second library produced a confusing `"1 Added, 1 Skipped"` status — the file was correctly added, but the "Skipped" message was a spurious artifact that contradicted what actually happened.

## Root cause

`LibraryIngestPipeline.block3GetOrCreateEntity` queried `ImageFiles` for matching hashes across **all** libraries:

```csharp
var imageFiles = dbContext.ImageFiles
    .Where(f => hashes.Contains(f.HeaderHash))
    .ToList();
```

When scanning library B with a file whose hash already existed in library A, the query returned library A's row. `UpdateNonHeaderFields` was then called on that row with library B's fileInfo, returned false (no size change), and emitted a "Skipped" status. The file still flowed through to the add path downstream because the `(hash, path)` tuple differed — so the file was correctly added to library B, but the user-visible counts lied.

## Fix

Scope the dedup query to the library currently being scanned. All messages in a single pipeline invocation come from the same library, so we derive the scope from the batch and lock the invariant with `.Distinct().Single()` so a future refactor that fanned multiple libraries into one pipeline would fault loudly rather than silently mis-scope:

```csharp
var libraryId = messages.Select(m => m.Value.LibraryId).Distinct().Single();
var imageFiles = dbContext.ImageFiles
    .Where(f => f.LibraryId == libraryId && hashes.Contains(f.HeaderHash))
    .ToList();
```

Libraries are logically independent, and the same physical file may legitimately live in more than one.

## Regression test

Added `Lumidex.Tests/LibraryIngestPipelineTests.SameFileInTwoLibraries_SecondLibraryScan_DoesNotEmitMisleadingSkipped`. Creates two libraries pointing at separate directories, drops the same XISF into each, scans both, asserts 1 Added / 0 Skipped on each.

Also added `Lumidex.Tests/Fixtures/TestDbContextFactory.cs` — a shared test helper that creates fresh `LumidexDbContext` instances pointing at the fixture's SQLite file, which the ingest pipeline requires (it expects an `IDbContextFactory`, not a shared context).

**Before fix (on `main` prior to this PR):**
```
[FAIL] SameFileInTwoLibraries_SecondLibraryScan_DoesNotEmitMisleadingSkipped
  Expected secondScanSkipped to be 0 ... but found 1 (difference of 1).
```

**After fix (this PR):**
```
Passed!  - Failed:     0, Passed:    15, Skipped:     0, Total:    15, Duration: 616 ms
```

## What this PR does not change

The fix is scoped intentionally. A few related concerns were surfaced during internal review and deliberately left out so each one can be considered on its own merits:

- **Quick Scan missing files with preserved mtime** — the other half of #66. Filed as a separate PR with its own reasoning (ctime fallback via platform P/Invoke).
- **Rename-with-preserved-mtime leaving orphan DB rows.** If a user renames a file within a library without updating mtime, the walker skips the file (current behavior), or — if picked up by the ctime fallback PR — the downstream pipeline creates a new row while the old path's row remains. Pre-existing dedup gap; not addressed here.
- **Concurrent-scan TOCTOU.** If a user somehow triggers two concurrent scans of the same library (e.g., double-click on "Scan"), there is a pre-existing race between block3's dedup `SELECT` and block6's `AddRange` where both can insert rows for the same file. The window is unchanged by this PR.
- **Discarded `SaveChanges` count + ignored progress-block `Post()` bool return.** Pre-existing silent-failure patterns in block3. Noted below — see "Caveat".

## Caveat worth naming

Pre-fix, the global hash query provided an **accidental cross-library recovery path** for a silently-failed `SaveChanges` on library A: a subsequent scan of library B touching the same hash would re-evaluate the row and could surface drift. That recovery path is **removed** by this PR, because the scoped query will not see library A's row when scanning library B. The silent-failure pattern itself (`int count = dbContext.SaveChanges();` where `count` is discarded) was pre-existing and not introduced here, but it matters materially more once the accidental cross-library recovery is gone. Surfacing this so the risk is explicit; a one-line `Log.Debug` in block3 would close the gap cleanly as a separate change.

## Notes

The `.Distinct().Single()` invariant-lock was chosen over `Debug.Assert` (compiled out in Release builds, so a production fan-in bug would sail past silently) and over an `Enumerable.Empty` early-return (which would swallow what is structurally an impossible-state signal). Bare `messages[0]` was the original draft but left a load-bearing calling-convention invariant with no runtime enforcement.
