### PR TITLE
Feature: Visual Target Summary Screen

### DIFF
--- a/Lumidex.Core/Data/LumidexDbContext.cs
+++ b/Lumidex.Core/Data/LumidexDbContext.cs
@@ -41,6 +41,12 @@ public class LumidexDbContext : DbContext
             .Property(x => x.CreatedOn)
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
+        // The target summary filters Type==Light then joins/aggregates on ObjectName; without this
+        // index the largest table is full-scanned several times per reload. ObjectName is TEXT
+        // COLLATE NOCASE, so the index inherits NOCASE and serves the case-insensitive join.
+        modelBuilder.Entity<ImageFile>()
+            .HasIndex(x => new { x.Type, x.ObjectName });
+
         modelBuilder.Entity<Library>()
             .Property(x => x.CreatedOn)
             .HasDefaultValueSql("CURRENT_TIMESTAMP");

--- a/Lumidex.Core/Data/LumidexDbContext.cs
+++ b/Lumidex.Core/Data/LumidexDbContext.cs
@@ -27,6 +27,8 @@ public class LumidexDbContext : DbContext
     public DbSet<ObjectAlias> ObjectAliases { get; set; }
     public DbSet<AstrobinFilter> AstrobinFilters { get; set; }
     public DbSet<PersistedFilter> PersistedFilters { get; set; }
+    public DbSet<Target> Targets { get; set; }
+    public DbSet<TargetNameMap> TargetNameMaps { get; set; }
 
     public LumidexDbContext(DbContextOptions<LumidexDbContext> options)
         : base(options)

--- a/Lumidex.Core/Data/Migrations/20260622213007_AddTargetSummary.Designer.cs
+++ b/Lumidex.Core/Data/Migrations/20260622213007_AddTargetSummary.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumidex.Core.Data.Migrations
 {
     [DbContext(typeof(LumidexDbContext))]
-    partial class LumidexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622213007_AddTargetSummary")]
+    partial class AddTargetSummary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.5");

--- a/Lumidex.Core/Data/Migrations/20260622213007_AddTargetSummary.cs
+++ b/Lumidex.Core/Data/Migrations/20260622213007_AddTargetSummary.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumidex.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTargetSummary : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Targets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    CanonicalName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Targets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TargetNameMaps",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    RawObjectName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false),
+                    TargetId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TargetNameMaps", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TargetNameMaps_Targets_TargetId",
+                        column: x => x.TargetId,
+                        principalTable: "Targets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetNameMaps_RawObjectName",
+                table: "TargetNameMaps",
+                column: "RawObjectName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetNameMaps_TargetId",
+                table: "TargetNameMaps",
+                column: "TargetId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TargetNameMaps");
+
+            migrationBuilder.DropTable(
+                name: "Targets");
+        }
+    }
+}

--- a/Lumidex.Core/Data/Migrations/20260622213336_AddImageFileObjectNameIndex.Designer.cs
+++ b/Lumidex.Core/Data/Migrations/20260622213336_AddImageFileObjectNameIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumidex.Core.Data.Migrations
 {
     [DbContext(typeof(LumidexDbContext))]
-    partial class LumidexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622213336_AddImageFileObjectNameIndex")]
+    partial class AddImageFileObjectNameIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.5");

--- a/Lumidex.Core/Data/Migrations/20260622213336_AddImageFileObjectNameIndex.cs
+++ b/Lumidex.Core/Data/Migrations/20260622213336_AddImageFileObjectNameIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumidex.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageFileObjectNameIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageFiles_Type_ObjectName",
+                table: "ImageFiles",
+                columns: new[] { "Type", "ObjectName" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ImageFiles_Type_ObjectName",
+                table: "ImageFiles");
+        }
+    }
+}

--- a/Lumidex.Core/Data/Target.cs
+++ b/Lumidex.Core/Data/Target.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumidex.Core.Data;
+
+// A canonical imaging target. One or more raw FITS OBJECT strings map to it through
+// TargetNameMap; the target summary aggregates integration time per target.
+public class Target
+{
+    public int Id { get; set; }
+
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string CanonicalName { get; set; } = null!;
+
+    public ICollection<TargetNameMap> NameMaps { get; set; } = new List<TargetNameMap>();
+}

--- a/Lumidex.Core/Data/TargetNameMap.cs
+++ b/Lumidex.Core/Data/TargetNameMap.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumidex.Core.Data;
+
+// One raw FITS-header OBJECT string maps to exactly one canonical Target. RawObjectName is unique
+// (NOCASE) and resolution trims it before keying, so ASCII-case variants ("M 31"/"m 31") and
+// whitespace-padded twins ("M 31 ") collapse to one map. The fold is ASCII-case + whitespace-trim
+// only; non-ASCII case variants are not folded, which is fine for the Latin/numeric catalog
+// designations FITS OBJECT carries in practice.
+[Index(nameof(RawObjectName), IsUnique = true)]
+public class TargetNameMap
+{
+    public int Id { get; set; }
+
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string RawObjectName { get; set; } = null!;
+
+    public int TargetId { get; set; }
+    public Target Target { get; set; } = null!;
+}

--- a/Lumidex.Core/DependencyInjection.cs
+++ b/Lumidex.Core/DependencyInjection.cs
@@ -19,6 +19,7 @@ public static class DependencyInjection
             => () => provider.GetRequiredService<LibraryIngestPipeline>());
 
         services.AddTransient<Targets.TargetResolutionService>();
+        services.AddTransient<Targets.TargetSummaryQuery>();
         
         services.AddDbContextFactory<LumidexDbContext>(options =>
         {

--- a/Lumidex.Core/DependencyInjection.cs
+++ b/Lumidex.Core/DependencyInjection.cs
@@ -17,6 +17,8 @@ public static class DependencyInjection
         services.AddTransient<LibraryIngestPipeline>();
         services.AddTransient<Func<LibraryIngestPipeline>>(provider
             => () => provider.GetRequiredService<LibraryIngestPipeline>());
+
+        services.AddTransient<Targets.TargetResolutionService>();
         
         services.AddDbContextFactory<LumidexDbContext>(options =>
         {

--- a/Lumidex.Core/Targets/FilterCanonicalizer.cs
+++ b/Lumidex.Core/Targets/FilterCanonicalizer.cs
@@ -1,0 +1,86 @@
+namespace Lumidex.Core.Targets;
+
+// Folds the many ways a filter gets named into one canonical label, so the integration bars merge
+// true synonyms (e.g. "H" and "Ha", or "Luminance" and "L") into a single segment and color them
+// consistently — while keeping genuinely different filters apart.
+//
+// Two filter naming systems coexist in real libraries, and Lumidex serves both:
+//   - Imaging (astrophotography): Luminance, Red/Green/Blue (or L/R/G/B), narrowband
+//     Ha/OIII/SII/Hb/He/NII, one-shot-color "Color", and multiband LPro / L-eNhance / LUltimate.
+//   - Photometric (science): Johnson-Cousins U B V R I.
+//
+// The ONLY names that overlap between the two systems are the bare letters "B" and "R". Everything
+// else is unambiguous: "U", "V", "I" only exist in the photometric system; "Luminance", "Green", the
+// narrowband and multiband names, and the colour words only exist in imaging. So the rule needs to
+// resolve just B and R, and it does so from context rather than special-casing any telescope:
+//
+//   A bare B/R is PHOTOMETRIC when the surrounding filter set shows photometric evidence — it
+//   contains U, V, or I (bands with no imaging meaning), OR it also carries the imaging WORD form
+//   (Blue/Red) of that colour, which means the bare letter must be the other system. Otherwise the
+//   letter is the imaging band.
+//
+// That one rule covers pure-imaging datasets (letters fold to LRGB), pure photometry (UBVRI stays
+// photometric), and mixed rigs that shoot both — with no per-telescope exceptions. The
+// disambiguation context is the telescope's whole filter set (passed in by the caller), so a scope's
+// B is classified the same way for every target on it.
+public static class FilterCanonicalizer
+{
+    // Unambiguous spelling variants -> canonical label (case-insensitive, so only distinct spellings
+    // are listed, not casings). The bare letters B and R are deliberately absent — they're resolved
+    // in Canonicalize by context.
+    private static readonly Dictionary<string, string> Direct = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["L"] = "L", ["Lum"] = "L", ["Luminance"] = "L",
+        ["Green"] = "Green", ["G"] = "Green",
+        ["Red"] = "Red",
+        ["Blue"] = "Blue",
+        ["Ha"] = "Ha", ["H"] = "Ha", ["Halpha"] = "Ha", ["H-alpha"] = "Ha", ["Hα"] = "Ha",
+        ["OIII"] = "OIII", ["O"] = "OIII", ["O3"] = "OIII",
+        ["SII"] = "SII", ["S"] = "SII", ["S2"] = "SII",
+        ["Hb"] = "Hb", ["Hbeta"] = "Hb", ["H-beta"] = "Hb", ["Hβ"] = "Hb",
+        ["He"] = "He", ["HeII"] = "He", ["HeI"] = "He",
+        ["NII"] = "NII", ["N"] = "NII", ["N2"] = "NII",
+        ["Color"] = "Color", ["Colour"] = "Color", ["OSC"] = "Color",
+        ["LPro"] = "LPro", ["L-Pro"] = "LPro",
+        ["LUltimate"] = "LUltimate", ["L-Ultimate"] = "LUltimate",
+        ["L-eNhance"] = "L-eNhance", ["LeNhance"] = "L-eNhance", ["L-Enhance"] = "L-eNhance", ["LEnhance"] = "L-eNhance",
+        ["U"] = "U", ["V"] = "V", ["I"] = "I", // photometric, unambiguous
+    };
+
+    // Maps one raw filter name to its canonical label. `datasetFilters` is the set of raw filter
+    // names that share this filter's disambiguation context (the telescope's whole filter set) —
+    // used only to resolve bare B/R. An empty or unrecognized name is returned unchanged (so
+    // "(No filter)" and any filter we don't know about pass through).
+    public static string Canonicalize(string? raw, IReadOnlyCollection<string> datasetFilters)
+    {
+        var name = (raw ?? string.Empty).Trim();
+        if (name.Length == 0)
+            return raw ?? string.Empty;
+
+        // Resolve the two ambiguous letters first, before the direct table.
+        if (name.Equals("B", StringComparison.OrdinalIgnoreCase))
+            return IsPhotometric("Blue", datasetFilters) ? "B" : "Blue";
+        if (name.Equals("R", StringComparison.OrdinalIgnoreCase))
+            return IsPhotometric("Red", datasetFilters) ? "R" : "Red";
+
+        return Direct.TryGetValue(name, out var canonical) ? canonical : name;
+    }
+
+    // Photometric evidence for a bare letter: the dataset carries a Johnson-Cousins-only band
+    // (U/V/I), or it carries the imaging word-form of the same colour alongside the letter (so the
+    // letter must be the other system).
+    private static bool IsPhotometric(string imagingWord, IReadOnlyCollection<string> datasetFilters)
+    {
+        foreach (var f in datasetFilters)
+        {
+            var t = f.Trim();
+            if (t.Equals("U", StringComparison.OrdinalIgnoreCase)
+                || t.Equals("V", StringComparison.OrdinalIgnoreCase)
+                || t.Equals("I", StringComparison.OrdinalIgnoreCase)
+                || t.Equals(imagingWord, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Lumidex.Core/Targets/TargetResolutionService.cs
+++ b/Lumidex.Core/Targets/TargetResolutionService.cs
@@ -1,11 +1,13 @@
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
+using System.Text;
 
 namespace Lumidex.Core.Targets;
 
-// Maps each FITS-header OBJECT string to a canonical Target so the summary can aggregate per
-// target. Deterministic and offline: a distinct object name mints a target the first time it is
-// seen and reuses it thereafter.
+// Maps each FITS-header OBJECT string to a canonical Target so the summary can aggregate per target.
+// Deterministic and offline: it folds pure FORMATTING variants of a name (case / whitespace /
+// punctuation) onto one target. Cross-catalog identity ("Tarantula Nebula" == "NGC 2070") is out of
+// scope here.
 public class TargetResolutionService
 {
     private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
@@ -13,48 +15,154 @@ public class TargetResolutionService
     public TargetResolutionService(IDbContextFactory<LumidexDbContext> dbContextFactory)
         => _dbContextFactory = dbContextFactory;
 
-    // Ensure every Light-frame object name has a target. Idempotent — a second call adds nothing.
+    // Two passes: first collapse any existing formatting-variant duplicates, then map any not-yet-
+    // mapped names. Idempotent — a second call finds nothing to merge and nothing new to add.
     public void EnsureTargetsResolved()
     {
         using var db = _dbContextFactory.CreateDbContext();
+        ConsolidateFormattingVariants(db);
         MapNewObjectNames(db);
     }
 
-    // Mint a target + name map for each distinct object name not already mapped. Names are matched
-    // case-insensitively (the map is unique NOCASE) and trimmed, since FITS space-pads OBJECT.
+    // Light identity key: lowercase, alphanumerics only. Collapses formatting variants of a name —
+    // "Bode's Galaxy"/"Bodes Galaxy", "NGC 2070"/"Ngc2070", "M 101"/"M101" — to one key. It does not
+    // understand catalog cross-references; names differing by real words stay distinct. Returns "" for
+    // a name with no alphanumerics.
+    //
+    // Knowingly lossy: stripping every non-alphanumeric also folds hyphenated designations ("M1-67"
+    // and "M167" collapse to one key). A hyphen-significance rule would re-split the "M 101"/"M101"
+    // variants this exists to merge, so it is accepted here; true catalog identity is future work.
+    private static string NormalizeKey(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+
+    // Merge targets whose names share a NormalizeKey into the one with the most Light frames (the
+    // dominant spelling), so an object split across spelling variants shows as one row. No-op once the
+    // library is clean.
+    private static void ConsolidateFormattingVariants(LumidexDbContext db)
+    {
+        var keyed = db.TargetNameMaps
+            .Select(m => new { m.RawObjectName, m.TargetId })
+            .AsEnumerable()
+            .Select(m => new { Key = NormalizeKey(m.RawObjectName), m.TargetId })
+            .Where(m => m.Key.Length > 0)
+            .ToList();
+
+        var groups = keyed
+            .GroupBy(m => m.Key)
+            .Where(g => g.Select(m => m.TargetId).Distinct().Count() > 1)
+            .ToList();
+        if (groups.Count == 0)
+            return;
+
+        var frames = FrameCountsByTarget(db);
+        foreach (var g in groups)
+        {
+            var ids = g.Select(m => m.TargetId).Distinct().ToList();
+            // Survivor = most Light frames; ties fall to the smallest id for determinism.
+            var survivorId = ids
+                .OrderByDescending(id => frames.GetValueOrDefault(id))
+                .ThenBy(id => id)
+                .First();
+            AbsorbInto(db, survivorId, ids.Where(id => id != survivorId).ToList());
+        }
+
+        db.SaveChanges();
+    }
+
+    // Map every distinct object name to a target. A name whose NormalizeKey already belongs to a
+    // target joins it (a new map, no new target); otherwise it mints a target. Idempotent — only
+    // names not already mapped are added.
     private static void MapNewObjectNames(LumidexDbContext db)
     {
-        var mapped = db.TargetNameMaps
-            .Select(m => m.RawObjectName)
+        var maps = db.TargetNameMaps
+            .Select(m => new { m.RawObjectName, m.TargetId })
             .AsEnumerable()
-            .Select(n => n.Trim())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .Select(m => new { Raw = m.RawObjectName.Trim(), m.TargetId })
+            .ToList();
+
+        var mappedRaw = maps.Select(m => m.Raw).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var keyToTarget = maps
+            .Select(m => new { m.Raw, Key = NormalizeKey(m.Raw), m.TargetId })
+            .Where(m => m.Key.Length > 0)
+            .GroupBy(m => m.Key)
+            // Post-consolidation there is one target per key; First() is safe.
+            .ToDictionary(g => g.Key, g => g.First().TargetId);
 
         var names = db.ImageFiles
             .Where(f => f.ObjectName != null && f.ObjectName != "")
             .Select(f => f.ObjectName!)
             .Distinct()
             .ToList()
-            // Whitespace-only names spawn no target; trim the rest to one identity. Client-side
-            // because SQLite TRIM strips only spaces, not tabs/newlines.
+            // Whitespace-only names spawn no target; trim the rest. Client-side because SQLite TRIM
+            // strips only spaces.
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .Select(n => n.Trim())
             .Distinct()
             .ToList();
 
+        // Targets minted earlier in THIS loop, so a second new variant of the same key joins the
+        // pending target instead of minting a duplicate before SaveChanges.
+        var pendingByKey = new Dictionary<string, Target>(StringComparer.Ordinal);
         var added = false;
+
         foreach (var name in names)
         {
-            if (!mapped.Add(name))
+            if (!mappedRaw.Add(name))
                 continue;
 
-            var target = new Target { CanonicalName = name };
-            db.Targets.Add(target);
-            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = target });
+            var key = NormalizeKey(name);
+            if (key.Length > 0 && keyToTarget.TryGetValue(key, out var existingId))
+            {
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, TargetId = existingId });
+            }
+            else if (key.Length > 0 && pendingByKey.TryGetValue(key, out var pending))
+            {
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = pending });
+            }
+            else
+            {
+                var target = new Target { CanonicalName = name };
+                db.Targets.Add(target);
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = target });
+                if (key.Length > 0)
+                    pendingByKey[key] = target;
+            }
             added = true;
         }
 
         if (added)
             db.SaveChanges();
+    }
+
+    // Light-frame count per target, via the trimmed name-map join, so consolidation keeps the
+    // dominant spelling.
+    private static Dictionary<int, int> FrameCountsByTarget(LumidexDbContext db)
+    {
+        return (from f in db.ImageFiles
+                where f.Type == ImageType.Light && f.ObjectName != null && f.ObjectName != ""
+                join m in db.TargetNameMaps on f.ObjectName!.Trim() equals m.RawObjectName
+                group f by m.TargetId into g
+                select new { TargetId = g.Key, Count = g.Count() })
+               .ToDictionary(x => x.TargetId, x => x.Count);
+    }
+
+    // Fold the absorbed targets into the survivor: repoint their name maps onto it, then delete them.
+    // Staged on the context so the caller's single SaveChanges commits the repoint and delete
+    // together.
+    private static void AbsorbInto(LumidexDbContext db, int survivorId, IReadOnlyList<int> absorbedIds)
+    {
+        if (absorbedIds.Count == 0)
+            return;
+
+        foreach (var map in db.TargetNameMaps.Where(m => absorbedIds.Contains(m.TargetId)))
+            map.TargetId = survivorId;
+
+        db.Targets.RemoveRange(db.Targets.Where(t => absorbedIds.Contains(t.Id)));
     }
 }

--- a/Lumidex.Core/Targets/TargetResolutionService.cs
+++ b/Lumidex.Core/Targets/TargetResolutionService.cs
@@ -1,0 +1,60 @@
+using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Core.Targets;
+
+// Maps each FITS-header OBJECT string to a canonical Target so the summary can aggregate per
+// target. Deterministic and offline: a distinct object name mints a target the first time it is
+// seen and reuses it thereafter.
+public class TargetResolutionService
+{
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+
+    public TargetResolutionService(IDbContextFactory<LumidexDbContext> dbContextFactory)
+        => _dbContextFactory = dbContextFactory;
+
+    // Ensure every Light-frame object name has a target. Idempotent — a second call adds nothing.
+    public void EnsureTargetsResolved()
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+        MapNewObjectNames(db);
+    }
+
+    // Mint a target + name map for each distinct object name not already mapped. Names are matched
+    // case-insensitively (the map is unique NOCASE) and trimmed, since FITS space-pads OBJECT.
+    private static void MapNewObjectNames(LumidexDbContext db)
+    {
+        var mapped = db.TargetNameMaps
+            .Select(m => m.RawObjectName)
+            .AsEnumerable()
+            .Select(n => n.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var names = db.ImageFiles
+            .Where(f => f.ObjectName != null && f.ObjectName != "")
+            .Select(f => f.ObjectName!)
+            .Distinct()
+            .ToList()
+            // Whitespace-only names spawn no target; trim the rest to one identity. Client-side
+            // because SQLite TRIM strips only spaces, not tabs/newlines.
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim())
+            .Distinct()
+            .ToList();
+
+        var added = false;
+        foreach (var name in names)
+        {
+            if (!mapped.Add(name))
+                continue;
+
+            var target = new Target { CanonicalName = name };
+            db.Targets.Add(target);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = target });
+            added = true;
+        }
+
+        if (added)
+            db.SaveChanges();
+    }
+}

--- a/Lumidex.Core/Targets/TargetSummaryQuery.cs
+++ b/Lumidex.Core/Targets/TargetSummaryQuery.cs
@@ -26,6 +26,8 @@ public class TargetSummaryQuery
     private const string NoFilter = "(No filter)";
     private const string Unnamed = "(Unnamed)";
 
+    private static readonly HashSet<string> EmptyScopeFilters = new(StringComparer.OrdinalIgnoreCase);
+
     private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
     public TargetSummaryQuery(IDbContextFactory<LumidexDbContext> dbContextFactory)
         => _dbContextFactory = dbContextFactory;
@@ -83,7 +85,18 @@ public class TargetSummaryQuery
                                                 x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last)))
             .ToList();
 
-        return RollUp(cells);
+        // Canonicalize each cell's filter using the scope's whole filter set as context (the
+        // bare-B/R rule), so true synonyms merge before the roll-up groups by filter.
+        var scopeFilters = cells
+            .GroupBy(c => c.Scope)
+            .ToDictionary(g => g.Key, g => g.Select(c => c.Filter).ToHashSet(StringComparer.OrdinalIgnoreCase));
+        var canonical = cells.Select(c => c with
+        {
+            Filter = FilterCanonicalizer.Canonicalize(c.Filter,
+                scopeFilters.TryGetValue(c.Scope, out var sf) ? sf : EmptyScopeFilters),
+        });
+
+        return RollUp(canonical);
     }
 
     private static Cell ToCell(int id, string name, string? telescopeName, string? filterName, double seconds, DateTime? first, DateTime? last)

--- a/Lumidex.Core/Targets/TargetSummaryQuery.cs
+++ b/Lumidex.Core/Targets/TargetSummaryQuery.cs
@@ -1,0 +1,114 @@
+using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Core.Targets;
+
+// One filter's integration on one scope. First/Last are the earliest/latest frame times.
+public record FilterIntegration(string Filter, double Hours, DateTime? First, DateTime? Last);
+
+// One scope (telescope) on a target. Hours is the sum of its filters; First/Last span them.
+public record ScopeIntegration(string Scope, DateTime? First, DateTime? Last, IReadOnlyList<FilterIntegration> Filters)
+{
+    public double Hours => Filters.Sum(f => f.Hours);
+}
+
+// One canonical target. Hours is the sum of its scopes; First/Last span them.
+public record TargetIntegration(int TargetId, string CanonicalName, DateTime? First, DateTime? Last, IReadOnlyList<ScopeIntegration> Scopes)
+{
+    public double Hours => Scopes.Sum(s => s.Hours);
+}
+
+// Aggregates Light-frame integration time target -> scope -> filter. Returns the tree unordered;
+// ordering is a view concern.
+public class TargetSummaryQuery
+{
+    private const string UnknownScope = "(Unknown scope)";
+    private const string NoFilter = "(No filter)";
+    private const string Unnamed = "(Unnamed)";
+
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+    public TargetSummaryQuery(IDbContextFactory<LumidexDbContext> dbContextFactory)
+        => _dbContextFactory = dbContextFactory;
+
+    private record Cell(int Id, string Name, string Scope, string Filter, double Hours, DateTime? First, DateTime? Last);
+
+    public IReadOnlyList<TargetIntegration> GetTargetSummary()
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+
+        // (target, scope, filter) -> seconds + date extents, over Light frames with a mapped name.
+        // Trim the ObjectName on the join so a space-padded twin matches the stored map.
+        var flat = (from f in db.ImageFiles.AsNoTracking()
+                    where f.Type == ImageType.Light
+                    join m in db.TargetNameMaps on f.ObjectName!.Trim() equals m.RawObjectName
+                    join t in db.Targets on m.TargetId equals t.Id
+                    group f by new { t.Id, t.CanonicalName, f.TelescopeName, f.FilterName } into g
+                    select new
+                    {
+                        g.Key.Id, g.Key.CanonicalName, g.Key.TelescopeName, g.Key.FilterName,
+                        Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                        First = g.Min(x => x.ObservationTimestampUtc),
+                        Last = g.Max(x => x.ObservationTimestampUtc),
+                    }).ToList();
+
+        // Light frames with no usable ObjectName -> a synthetic "(Unnamed)" pile.
+        var unnamed = (from f in db.ImageFiles.AsNoTracking()
+                       where f.Type == ImageType.Light && (f.ObjectName == null || f.ObjectName!.Trim() == "")
+                       group f by new { f.TelescopeName, f.FilterName } into g
+                       select new
+                       {
+                           g.Key.TelescopeName, g.Key.FilterName,
+                           Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                           First = g.Min(x => x.ObservationTimestampUtc),
+                           Last = g.Max(x => x.ObservationTimestampUtc),
+                       }).ToList();
+
+        // Light frames named but not yet mapped -> a self-named synthetic row (a backstop so frames
+        // never silently vanish between a scan and the next resolve).
+        var unmapped = (from f in db.ImageFiles.AsNoTracking()
+                        where f.Type == ImageType.Light && f.ObjectName != null && f.ObjectName!.Trim() != ""
+                              && !db.TargetNameMaps.Any(m => m.RawObjectName == f.ObjectName!.Trim())
+                        group f by new { ObjectName = f.ObjectName!.Trim(), f.TelescopeName, f.FilterName } into g
+                        select new
+                        {
+                            g.Key.ObjectName, g.Key.TelescopeName, g.Key.FilterName,
+                            Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                            First = g.Min(x => x.ObservationTimestampUtc),
+                            Last = g.Max(x => x.ObservationTimestampUtc),
+                        }).ToList();
+
+        var cells = flat.Select(x => ToCell(x.Id, x.CanonicalName, x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last))
+            .Concat(unnamed.Select(x => ToCell(0, Unnamed, x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last)))
+            .Concat(unmapped.Select(x => ToCell(0, string.IsNullOrWhiteSpace(x.ObjectName) ? Unnamed : x.ObjectName!,
+                                                x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last)))
+            .ToList();
+
+        return RollUp(cells);
+    }
+
+    private static Cell ToCell(int id, string name, string? telescopeName, string? filterName, double seconds, DateTime? first, DateTime? last)
+        => new(id, name,
+            string.IsNullOrEmpty(telescopeName) ? UnknownScope : telescopeName,
+            string.IsNullOrEmpty(filterName) ? NoFilter : filterName,
+            seconds / 3600.0, first, last);
+
+    private static IReadOnlyList<TargetIntegration> RollUp(IEnumerable<Cell> cells)
+    {
+        return cells
+            .GroupBy(c => (c.Id, c.Name))
+            .Select(tg =>
+            {
+                var scopes = tg.GroupBy(c => c.Scope)
+                    .Select(sg =>
+                    {
+                        var filters = sg.GroupBy(c => c.Filter)
+                            .Select(fg => new FilterIntegration(fg.Key, fg.Sum(c => c.Hours), fg.Min(c => c.First), fg.Max(c => c.Last)))
+                            .ToList();
+                        return new ScopeIntegration(sg.Key, filters.Min(f => f.First), filters.Max(f => f.Last), filters);
+                    })
+                    .ToList();
+                return new TargetIntegration(tg.Key.Id, tg.Key.Name, scopes.Min(s => s.First), scopes.Max(s => s.Last), scopes);
+            })
+            .ToList();
+    }
+}

--- a/Lumidex.Tests/FilterCanonicalizerTests.cs
+++ b/Lumidex.Tests/FilterCanonicalizerTests.cs
@@ -1,0 +1,53 @@
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Tests;
+
+// Pure (no DB) tests of the filter-name folding and the bare-B/R disambiguation.
+public class FilterCanonicalizerTests
+{
+    private static readonly string[] None = [];
+
+    [Theory]
+    [InlineData("H", "Ha")]
+    [InlineData("Ha", "Ha")]
+    [InlineData("Halpha", "Ha")]
+    [InlineData("Lum", "L")]
+    [InlineData("Luminance", "L")]
+    [InlineData("G", "Green")]
+    [InlineData("O", "OIII")]
+    [InlineData("S", "SII")]
+    [InlineData("OSC", "Color")]
+    public void Canonicalize_FoldsUnambiguousSynonyms(string raw, string expected)
+        => FilterCanonicalizer.Canonicalize(raw, None).Should().Be(expected);
+
+    [Fact]
+    public void Canonicalize_UnknownFilter_PassesThrough()
+        => FilterCanonicalizer.Canonicalize("Tri-Band", None).Should().Be("Tri-Band");
+
+    // A bare B/R with no photometric evidence is the imaging band.
+    [Fact]
+    public void Canonicalize_BareLetters_WithoutPhotometricEvidence_AreImaging()
+    {
+        FilterCanonicalizer.Canonicalize("B", new[] { "L", "R", "G", "B" }).Should().Be("Blue");
+        FilterCanonicalizer.Canonicalize("R", new[] { "L", "R", "G", "B" }).Should().Be("Red");
+    }
+
+    // A Johnson-Cousins band (U/V/I) in the set marks bare B/R as photometric.
+    [Fact]
+    public void Canonicalize_BareLetters_WithUVI_ArePhotometric()
+    {
+        var set = new[] { "U", "B", "V", "R", "I" };
+        FilterCanonicalizer.Canonicalize("B", set).Should().Be("B");
+        FilterCanonicalizer.Canonicalize("R", set).Should().Be("R");
+    }
+
+    // The imaging WORD form alongside the bare letter marks the letter as the other (photometric)
+    // system — a scope shooting both Blue and B keeps them distinct.
+    [Fact]
+    public void Canonicalize_BareLetter_AlongsideWordForm_IsPhotometric()
+    {
+        var set = new[] { "Blue", "B", "Red", "R" };
+        FilterCanonicalizer.Canonicalize("B", set).Should().Be("B");
+        FilterCanonicalizer.Canonicalize("Blue", set).Should().Be("Blue");
+    }
+}

--- a/Lumidex.Tests/Fixtures/DatabaseFixture.cs
+++ b/Lumidex.Tests/Fixtures/DatabaseFixture.cs
@@ -9,6 +9,9 @@ public class DatabaseFixture : IDisposable
 
     public string DatabaseFilename { get; }
 
+    // Exposed so tests can build their own fresh contexts against the same DB.
+    public DbContextOptions<LumidexDbContext> Options { get; }
+
     public DatabaseFixture()
     {
         var tempFilename = $"lumidex-{Path.GetFileName(Path.GetTempFileName())}.db";
@@ -20,7 +23,8 @@ public class DatabaseFixture : IDisposable
             .EnableSensitiveDataLogging(false);
 
         Directory.CreateDirectory(Path.GetDirectoryName(DatabaseFilename)!);
-        DbContext = new LumidexDbContext(builder.Options);
+        Options = builder.Options;
+        DbContext = new LumidexDbContext(Options);
         DbContext.Database.EnsureCreated();
     }
 

--- a/Lumidex.Tests/TargetResolutionServiceTests.cs
+++ b/Lumidex.Tests/TargetResolutionServiceTests.cs
@@ -1,0 +1,109 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Tests.Fixtures;
+
+namespace Lumidex.Tests;
+
+// Each test needs an isolated DB; the ctor wipes and recreates the schema so seeded rows from one
+// test never leak into the next. The fixture itself is created once per class by IClassFixture.
+public class TargetResolutionServiceTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetResolutionServiceTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetResolutionService Service() => new(new TestDbContextFactory(_fx.DatabaseFilename));
+
+    [Fact]
+    public void EnsureTargetsResolved_CreatesOneTargetPerDistinctName_AndIsIdempotent()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "a", Path = "/a", ObjectName = "M 31",  Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "b", Path = "/b", ObjectName = "M 31",  Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "c", Path = "/c", ObjectName = "M 104", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "d", Path = "/d", ObjectName = null,    Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        var svc = Service();
+        svc.EnsureTargetsResolved();
+        svc.EnsureTargetsResolved();   // idempotent
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).OrderBy(x => x)
+            .Should().BeEquivalentTo(new[] { "M 104", "M 31" });   // null ObjectName produces no target
+        verify.TargetNameMaps.Should().HaveCount(2);
+    }
+
+    // A whitespace-only ObjectName ("   ", "\t") is treated as empty: no target, no map. SQLite's
+    // TRIM strips only spaces, so the tab case proves the filter runs client-side.
+    [Fact]
+    public void EnsureTargetsResolved_WhitespaceObjectName_CreatesNoTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "sp",   Path = "/sp",   ObjectName = "   ",  Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "tab",  Path = "/tab",  ObjectName = "\t",   Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "real", Path = "/real", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).Should().BeEquivalentTo(new[] { "M 31" });
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+
+    // Case-variant ObjectNames ("M 31" / "m 31") collapse to ONE target — the NOCASE map.
+    [Fact]
+    public void EnsureTargetsResolved_CaseVariantObjectNames_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "u", Path = "/u", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "l", Path = "/l", ObjectName = "m 31", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+
+    // FITS space-pads OBJECT, so "M 31" and "M 31 " arrive as distinct strings; both trim to one
+    // identity and collapse to ONE target + ONE map rather than splitting integration across two.
+    [Fact]
+    public void EnsureTargetsResolved_WhitespacePaddedObjectNames_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "p", Path = "/p", ObjectName = "M 31",  Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "t", Path = "/t", ObjectName = "M 31 ", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+}

--- a/Lumidex.Tests/TargetResolutionServiceTests.cs
+++ b/Lumidex.Tests/TargetResolutionServiceTests.cs
@@ -106,4 +106,81 @@ public class TargetResolutionServiceTests : IClassFixture<DatabaseFixture>, IDis
         verify.Targets.Should().ContainSingle();
         verify.TargetNameMaps.Should().ContainSingle();
     }
+
+    // Formatting variants of a name in the raw data (whitespace / punctuation / case) map to ONE
+    // target each, not several.
+    [Fact]
+    public void EnsureTargetsResolved_FormattingVariants_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="NGC 2070",      Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Ngc2070",       Type=ImageType.Light, LibraryId=1 }, // whitespace+case twin
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Bode's Galaxy", Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="d", Path="/d", ObjectName="Bodes Galaxy",  Type=ImageType.Light, LibraryId=1 }); // apostrophe twin
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().HaveCount(2);                          // NGC 2070 family + Bode's family
+        verify.TargetNameMaps.Should().HaveCount(4);                  // every raw spelling still maps
+        verify.TargetNameMaps.Select(m => m.TargetId).Distinct().Should().HaveCount(2);
+    }
+
+    // Existing fragmentation (separate targets from a prior run) is consolidated on the next resolve:
+    // formatting-variant targets collapse into the most-imaged one.
+    [Fact]
+    public void EnsureTargetsResolved_ConsolidatesExistingVariantTargets_ByDominantSpelling()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var big = new Target { CanonicalName = "M101" };           // dominant spelling (more frames)
+            var small = new Target { CanonicalName = "M 101" };
+            db.Targets.AddRange(big, small);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = big });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = small });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="4", Path="/4", ObjectName="M 101", Type=ImageType.Light, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();                      // the two variant targets merged
+        verify.Targets.Single().CanonicalName.Should().Be("M101");    // survivor = dominant spelling
+        verify.TargetNameMaps.Should().HaveCount(2);                  // both raw spellings still map...
+        verify.TargetNameMaps.Select(m => m.TargetId).Distinct().Should().ContainSingle(); // ...onto one target
+    }
+
+    // The boundary: names that differ by real WORDS are NOT merged (no catalog knowledge).
+    // "Tarantula Nebula" vs "NGC 2070", and "Horsehead" vs "Horsehead Nebula", stay separate.
+    [Fact]
+    public void EnsureTargetsResolved_DifferentWordNames_StaySeparate()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Tarantula Nebula", Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="NGC 2070",         Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Horsehead",        Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="d", Path="/d", ObjectName="Horsehead Nebula", Type=ImageType.Light, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        Service().EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).OrderBy(x => x)
+            .Should().BeEquivalentTo(new[] { "Horsehead", "Horsehead Nebula", "NGC 2070", "Tarantula Nebula" });
+    }
 }

--- a/Lumidex.Tests/TargetSummaryQueryTests.cs
+++ b/Lumidex.Tests/TargetSummaryQueryTests.cs
@@ -1,0 +1,88 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Tests.Fixtures;
+
+namespace Lumidex.Tests;
+
+public class TargetSummaryQueryTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetSummaryQueryTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetSummaryQuery Query() => new(new TestDbContextFactory(_fx.DatabaseFilename));
+
+    // Light frames roll up target -> scope -> filter with hours summed at each level.
+    [Fact]
+    public void GetTargetSummary_RollsUpHoursByScopeAndFilter()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="OIII", Exposure=1*3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var target = Query().GetTargetSummary().Single(r => r.CanonicalName == "M 31");
+        target.Hours.Should().BeApproximately(6, 1e-6);                       // 2 + 3 + 1
+
+        var scope = target.Scopes.Should().ContainSingle().Subject;
+        scope.Scope.Should().Be("T20");
+        scope.Hours.Should().BeApproximately(6, 1e-6);
+        scope.Filters.Single(f => f.Filter == "Ha").Hours.Should().BeApproximately(5, 1e-6);    // 2 + 3
+        scope.Filters.Single(f => f.Filter == "OIII").Hours.Should().BeApproximately(1, 1e-6);
+    }
+
+    // Date extents span all the frames of a group, ignoring null observation times.
+    [Fact]
+    public void GetTargetSummary_DateExtents_SpanFrames()
+    {
+        var d1 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var d2 = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, ObservationTimestampUtc=d2, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, ObservationTimestampUtc=d1, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var row = Query().GetTargetSummary().Single();
+        row.First.Should().Be(d1);
+        row.Last.Should().Be(d2);
+    }
+
+    // Light frames with no usable ObjectName roll up under the synthetic "(Unnamed)" row.
+    [Fact]
+    public void GetTargetSummary_UnnamedFrames_RollUpUnderUnnamedRow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.Add(new ImageFile { HeaderHash="u", Path="/u", ObjectName=null, Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetSummary();
+        var unnamed = rows.Should().ContainSingle().Subject;
+        unnamed.TargetId.Should().Be(0);
+        unnamed.CanonicalName.Should().Be("(Unnamed)");
+        unnamed.Hours.Should().BeApproximately(1, 1e-6);
+    }
+}

--- a/Lumidex.Tests/TargetSummaryQueryTests.cs
+++ b/Lumidex.Tests/TargetSummaryQueryTests.cs
@@ -85,4 +85,27 @@ public class TargetSummaryQueryTests : IClassFixture<DatabaseFixture>, IDisposab
         unnamed.CanonicalName.Should().Be("(Unnamed)");
         unnamed.Hours.Should().BeApproximately(1, 1e-6);
     }
+
+    // Filter synonyms canonicalize before the roll-up, so "H" and "Ha" merge into one filter row
+    // with their hours summed.
+    [Fact]
+    public void GetTargetSummary_CanonicalizesFilterSynonyms()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="H",  Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetSummary().Single().Scopes.Single();
+        scope.Filters.Should().ContainSingle();                         // H + Ha fold to one canonical filter
+        scope.Filters.Single().Filter.Should().Be("Ha");
+        scope.Filters.Single().Hours.Should().BeApproximately(2, 1e-6); // 1h + 1h
+    }
 }

--- a/Lumidex.Tests/TargetSummaryViewModelTests.cs
+++ b/Lumidex.Tests/TargetSummaryViewModelTests.cs
@@ -1,0 +1,53 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Features.TargetSummary;
+using Lumidex.Services;
+using Lumidex.Tests.Fixtures;
+
+namespace Lumidex.Tests;
+
+public class TargetSummaryViewModelTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetSummaryViewModelTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetSummaryViewModel BuildViewModel()
+    {
+        var factory = new TestDbContextFactory(_fx.DatabaseFilename);
+        return new TargetSummaryViewModel(
+            new TargetResolutionService(factory),
+            new TargetSummaryQuery(factory),
+            new DialogService());
+    }
+
+    // The bar reference (the "share of the largest" denominator) must exclude the synthetic
+    // "(Unnamed)" pile, which is often the biggest — otherwise every real target's bar scales
+    // against the junk row. Seed an unnamed pile LARGER than the one real target and assert the
+    // real target's ReferenceMax is its own hours, not the bigger pile.
+    [Fact]
+    public async Task Reload_ReferenceMax_ExcludesUnnamedPile()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="r", Path="/r", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="u", Path="/u", ObjectName=null,   Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=7200, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+
+        var m31 = vm.Targets.Single(t => t.CanonicalName == "M 31");
+        m31.ReferenceMax.Should().BeApproximately(1.0, 1e-6);   // its own 1h, not the unnamed 2h
+        m31.Remainder.Should().BeApproximately(0, 1e-6);        // it is the largest real target
+    }
+}

--- a/Lumidex.Tests/TargetSummaryViewModelTests.cs
+++ b/Lumidex.Tests/TargetSummaryViewModelTests.cs
@@ -50,4 +50,27 @@ public class TargetSummaryViewModelTests : IClassFixture<DatabaseFixture>, IDisp
         m31.ReferenceMax.Should().BeApproximately(1.0, 1e-6);   // its own 1h, not the unnamed 2h
         m31.Remainder.Should().BeApproximately(0, 1e-6);        // it is the largest real target
     }
+
+    // Changing the sort re-orders the loaded rows in memory (no DB reload). Hours are set inverse to
+    // the alphabetical order so the two sort modes produce different orders.
+    [Fact]
+    public async Task Sort_ReordersLoadedRows()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 104", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600,   LibraryId=1 }, // 1h
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31",  Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=2*3600, LibraryId=1 }); // 2h
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        vm.Targets.Select(t => t.CanonicalName).Should().ContainInOrder("M 31", "M 104");   // default: most data first
+
+        vm.SortBy = TargetSummarySort.Alphabetical;
+        vm.SortAscending = true;
+        vm.Targets.Select(t => t.CanonicalName).Should().ContainInOrder("M 104", "M 31");    // alphabetical ascending
+    }
 }

--- a/Lumidex/Converters/FilterColorConverter.cs
+++ b/Lumidex/Converters/FilterColorConverter.cs
@@ -1,0 +1,62 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using System.Globalization;
+
+namespace Lumidex.Converters;
+
+// Maps a filter label to its bar-segment color. Any label not in the palette (including the
+// "(No filter)" bucket and genuinely unknown filters) falls back to a neutral gray so every
+// segment still renders. Returns an IBrush so it binds straight to a Rectangle Fill.
+//
+// The palette covers the common imaging filters (Luminance, RGB, the SHO + extra narrowbands, OSC
+// "Color", multiband) and the Johnson-Cousins photometric letters (U B V R I) in shifted shades of
+// the same hue family, so a photometric "B"/"R" reads as blue/red but distinct from imaging
+// "Blue"/"Red". Folding filter synonyms ("H" -> "Ha") onto one label is a separate concern.
+public class FilterColorConverter : IValueConverter
+{
+    public static readonly FilterColorConverter Instance = new();
+
+    private static readonly IBrush Default = new ImmutableSolidColorBrush(Color.Parse("#8a8f99"));
+
+    private static readonly Dictionary<string, IBrush> Palette =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Imaging — broadband
+            ["L"] = Brush("#d8dde6"),
+            ["Red"] = Brush("#e0524e"),
+            ["Green"] = Brush("#56c073"),
+            ["Blue"] = Brush("#5b8def"),
+            // Imaging — narrowband
+            ["Ha"] = Brush("#b3304d"),
+            ["OIII"] = Brush("#1fb6a8"),
+            ["SII"] = Brush("#d9a441"),
+            ["Hb"] = Brush("#45b6d8"),
+            ["He"] = Brush("#8e6fd0"),
+            ["NII"] = Brush("#e07a3c"),
+            // Imaging — one-shot-color + multiband
+            ["Color"] = Brush("#b89ad0"),
+            ["LPro"] = Brush("#aab3c0"),
+            ["LUltimate"] = Brush("#b154a6"),
+            ["L-eNhance"] = Brush("#5bbf9e"),
+            // Photometric (Johnson-Cousins) — shifted shades, distinct from imaging
+            ["U"] = Brush("#6a4fb0"),
+            ["B"] = Brush("#2f4bb0"),
+            ["V"] = Brush("#9cbf3a"),
+            ["R"] = Brush("#a83228"),
+            ["I"] = Brush("#6e2b2b"),
+        };
+
+    private static IBrush Brush(string hex) => new ImmutableSolidColorBrush(Color.Parse(hex));
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string s && Palette.TryGetValue(s.Trim(), out var brush))
+            return brush;
+
+        return Default;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Lumidex/Converters/TargetSummarySortLabelConverter.cs
+++ b/Lumidex/Converters/TargetSummarySortLabelConverter.cs
@@ -1,0 +1,24 @@
+using Avalonia.Data.Converters;
+using Lumidex.Features.TargetSummary;
+using System.Globalization;
+
+namespace Lumidex.Converters;
+
+// Maps the TargetSummarySort enum to a human-readable label for the sort dropdown (the raw enum
+// names read poorly in the UI).
+public class TargetSummarySortLabelConverter : IValueConverter
+{
+    public static readonly TargetSummarySortLabelConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
+    {
+        TargetSummarySort.Alphabetical => "Alphabetical",
+        TargetSummarySort.DataAcquired => "Total Data Acquired",
+        TargetSummarySort.FirstAcquired => "First Acquired",
+        TargetSummarySort.LastAcquired => "Most Recent",
+        _ => value?.ToString(),
+    };
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Lumidex/Features/Main/MainViewModel.cs
+++ b/Lumidex/Features/Main/MainViewModel.cs
@@ -9,6 +9,7 @@ using Lumidex.Features.Plot;
 using Lumidex.Features.Settings;
 using Lumidex.Features.SideNavBar;
 using Lumidex.Features.Tags;
+using Lumidex.Features.TargetSummary;
 using Lumidex.Services;
 
 namespace Lumidex.Features.Main;
@@ -24,6 +25,7 @@ public partial class MainViewModel : ViewModelBase,
     private readonly TagManagerViewModel _tagManagerViewModel;
     private readonly LibraryManagerViewModel _libraryManagerViewModel;
     private readonly PlotManagerViewModel _plotManagerViewModel;
+    private readonly TargetSummaryViewModel _targetSummaryViewModel;
     private readonly MainSettingsViewModel _settingsViewModel;
 
     [ObservableProperty]
@@ -45,6 +47,7 @@ public partial class MainViewModel : ViewModelBase,
         TagManagerViewModel tagManagerViewModel,
         LibraryManagerViewModel libraryManagerViewModel,
         PlotManagerViewModel plotManagerViewModel,
+        TargetSummaryViewModel targetSummaryViewModel,
         MainSettingsViewModel settingsViewModel)
     {
         _systemService = systemService;
@@ -56,6 +59,7 @@ public partial class MainViewModel : ViewModelBase,
         _tagManagerViewModel = tagManagerViewModel;
         _libraryManagerViewModel = libraryManagerViewModel;
         _plotManagerViewModel = plotManagerViewModel;
+        _targetSummaryViewModel = targetSummaryViewModel;
         _settingsViewModel = settingsViewModel;
 
         // 28px for MacOS so traffic light is vertically centered.
@@ -89,6 +93,7 @@ public partial class MainViewModel : ViewModelBase,
             SideNavBarViewModel.TagsTabName => _tagManagerViewModel,
             SideNavBarViewModel.LibraryTabName => _libraryManagerViewModel,
             SideNavBarViewModel.PlotTabName => _plotManagerViewModel,
+            SideNavBarViewModel.TargetsTabName => _targetSummaryViewModel,
             // Lower Tabs
             SideNavBarViewModel.SettingsTabName => _settingsViewModel,
             _ => throw new NotImplementedException(),

--- a/Lumidex/Features/SideNavBar/SideNavBarViewModel.cs
+++ b/Lumidex/Features/SideNavBar/SideNavBarViewModel.cs
@@ -11,6 +11,7 @@ public partial class SideNavBarViewModel : ViewModelBase,
     public const string TagsTabName = "Tags";
     public const string LibraryTabName = "Library";
     public const string PlotTabName = "Plot";
+    public const string TargetsTabName = "Targets";
 
     // Lower Tabs
     public const string SettingsTabName = "Settings";
@@ -44,6 +45,12 @@ public partial class SideNavBarViewModel : ViewModelBase,
                 Name = PlotTabName,
                 ToolTipText = "Plot your data",
                 Icon = "mdi-chart-line",
+            },
+            new()
+            {
+                Name = TargetsTabName,
+                ToolTipText = "Integration time per target",
+                Icon = "mdi-target",
             },
             new()
             {

--- a/Lumidex/Features/TargetSummary/TargetRowViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetRowViewModel.cs
@@ -35,6 +35,8 @@ public partial class TargetRowViewModel : ObservableObject
     public required int TargetId { get; init; }
     public required string CanonicalName { get; init; }
     public required IReadOnlyList<ScopeRowViewModel> Scopes { get; init; }
+    public DateTime? First { get; init; }
+    public DateTime? Last { get; init; }
     public double ReferenceMax { get; set; }
 
     [ObservableProperty] public partial bool IsExpanded { get; set; }

--- a/Lumidex/Features/TargetSummary/TargetRowViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetRowViewModel.cs
@@ -1,0 +1,54 @@
+namespace Lumidex.Features.TargetSummary;
+
+// One colored slice of a bar: a filter's acquired hours.
+public record BarSegment(string Filter, double Hours);
+
+// A filter row — the leaf of the tree. The bar's filled portion is its hours; the unfilled tail
+// scales the row to the largest target (ReferenceMax) for a "share of the largest" comparison.
+public class FilterRowViewModel
+{
+    public required string Filter { get; init; }
+    public required double Hours { get; init; }
+    public double ReferenceMax { get; set; }
+    public double Remainder => Math.Max(0, ReferenceMax - Hours);
+    public IReadOnlyList<BarSegment> Segments => [new BarSegment(Filter, Hours)];
+}
+
+// A scope (telescope) row. Hours is the sum of its filters; it expands to show them.
+public partial class ScopeRowViewModel : ObservableObject
+{
+    public required string Scope { get; init; }
+    public required IReadOnlyList<FilterRowViewModel> Filters { get; init; }
+    public double ReferenceMax { get; set; }
+
+    [ObservableProperty] public partial bool IsExpanded { get; set; }
+
+    public double Hours => Filters.Sum(f => f.Hours);
+    public double Remainder => Math.Max(0, ReferenceMax - Hours);
+    public IReadOnlyList<BarSegment> Segments => Filters.Select(f => new BarSegment(f.Filter, f.Hours)).ToList();
+}
+
+// A canonical target row. A single-scope target hides the scope layer (CanExpand false) and shows
+// its filters directly; multi-scope targets expand into independently-expandable scopes.
+public partial class TargetRowViewModel : ObservableObject
+{
+    public required int TargetId { get; init; }
+    public required string CanonicalName { get; init; }
+    public required IReadOnlyList<ScopeRowViewModel> Scopes { get; init; }
+    public double ReferenceMax { get; set; }
+
+    [ObservableProperty] public partial bool IsExpanded { get; set; }
+
+    public double Hours => Scopes.Sum(s => s.Hours);
+    public double Remainder => Math.Max(0, ReferenceMax - Hours);
+
+    public bool CanExpand => Scopes.Count > 1;
+    public IReadOnlyList<FilterRowViewModel> Filters => Scopes.Count == 1 ? Scopes[0].Filters : [];
+
+    // Target-level bar segments: each filter's hours summed across the target's scopes.
+    public IReadOnlyList<BarSegment> Segments => Scopes
+        .SelectMany(s => s.Filters)
+        .GroupBy(f => f.Filter)
+        .Select(g => new BarSegment(g.Key, g.Sum(f => f.Hours)))
+        .ToList();
+}

--- a/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
+++ b/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
@@ -1,0 +1,220 @@
+<UserControl
+    x:Class="Lumidex.Features.TargetSummary.TargetSummaryView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converter="using:Lumidex.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:i="https://github.com/projektanker/icons.avalonia"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ts="using:Lumidex.Features.TargetSummary"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:DataType="ts:TargetSummaryViewModel"
+    mc:Ignorable="d">
+
+    <!-- Implicit template (in DataTemplates, not Resources, so it applies by type) for the filter
+         leaf row. Every binding reads off the row's own DataContext — never an ancestor/#element
+         binding, which crashes Avalonia's binding-error logger in these deferred expander lists.
+         The bar is drawn at raw hours and scaled to fit by a Viewbox, so no width binding is needed. -->
+    <UserControl.DataTemplates>
+        <DataTemplate DataType="ts:FilterRowViewModel">
+            <Grid Margin="0,1" ColumnDefinitions="240,64,*">
+                <TextBlock
+                    Grid.Column="0"
+                    Margin="48,0,0,0"
+                    VerticalAlignment="Center"
+                    Opacity="0.8"
+                    Text="{Binding Filter}" />
+                <TextBlock
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Opacity="0.8"
+                    TextAlignment="Right"
+                    Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                <Border
+                    Grid.Column="2"
+                    Height="14"
+                    MinWidth="80"
+                    Margin="8,0"
+                    VerticalAlignment="Center"
+                    Background="#22FFFFFF"
+                    ClipToBounds="True"
+                    CornerRadius="4">
+                    <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                        <StackPanel Orientation="Horizontal">
+                            <ItemsControl ItemsSource="{Binding Segments}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="ts:BarSegment">
+                                        <Rectangle
+                                            Height="12"
+                                            Width="{Binding Hours}"
+                                            Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                            ToolTip.Tip="{Binding Filter}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Rectangle Height="12" Width="{Binding Remainder}" Fill="Transparent" />
+                        </StackPanel>
+                    </Viewbox>
+                </Border>
+            </Grid>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <DockPanel Margin="8">
+        <StackPanel
+            Margin="0,0,0,8"
+            DockPanel.Dock="Top"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button Command="{Binding RefreshCommand}" Content="Refresh" />
+        </StackPanel>
+
+        <ScrollViewer>
+            <ItemsControl ItemsSource="{Binding Targets}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="ts:TargetRowViewModel">
+                        <StackPanel>
+                            <!-- Target row: same column geometry as the scope/filter rows so the bars line up. -->
+                            <Grid Margin="0,3" ColumnDefinitions="240,64,*">
+                                <DockPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <ToggleButton
+                                        DockPanel.Dock="Left"
+                                        Margin="0,0,4,0"
+                                        Padding="2,0"
+                                        VerticalAlignment="Center"
+                                        Background="Transparent"
+                                        IsChecked="{Binding IsExpanded}"
+                                        IsVisible="{Binding CanExpand}"
+                                        ToolTip.Tip="Show the per-telescope breakdown">
+                                        <i:Icon FontSize="14" Value="mdi-chevron-right" />
+                                    </ToggleButton>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        FontWeight="SemiBold"
+                                        Text="{Binding CanonicalName}"
+                                        TextTrimming="CharacterEllipsis"
+                                        ToolTip.Tip="{Binding CanonicalName}" />
+                                </DockPanel>
+                                <TextBlock
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    TextAlignment="Right"
+                                    Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                                <Border
+                                    Grid.Column="2"
+                                    Height="16"
+                                    MinWidth="80"
+                                    Margin="8,0"
+                                    VerticalAlignment="Center"
+                                    Background="#22FFFFFF"
+                                    ClipToBounds="True"
+                                    CornerRadius="4">
+                                    <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                                        <StackPanel Orientation="Horizontal">
+                                            <ItemsControl ItemsSource="{Binding Segments}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="ts:BarSegment">
+                                                        <Rectangle
+                                                            Height="14"
+                                                            Width="{Binding Hours}"
+                                                            Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                                            ToolTip.Tip="{Binding Filter}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                            <Rectangle Height="14" Width="{Binding Remainder}" Fill="Transparent" />
+                                        </StackPanel>
+                                    </Viewbox>
+                                </Border>
+                            </Grid>
+
+                            <!-- Expanded breakdown: scope rows (multi-scope) each followed by its filters,
+                                 OR the filters directly (single-scope). -->
+                            <StackPanel Margin="0,0,0,4" IsVisible="{Binding IsExpanded}">
+                                <ItemsControl IsVisible="{Binding CanExpand}" ItemsSource="{Binding Scopes}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="ts:ScopeRowViewModel">
+                                            <StackPanel>
+                                                <Grid Margin="0,4,0,1" ColumnDefinitions="240,64,*">
+                                                    <DockPanel Grid.Column="0" Margin="20,0,0,0" VerticalAlignment="Center">
+                                                        <ToggleButton
+                                                            DockPanel.Dock="Left"
+                                                            Margin="0,0,4,0"
+                                                            Padding="2,0"
+                                                            VerticalAlignment="Center"
+                                                            Background="Transparent"
+                                                            IsChecked="{Binding IsExpanded}"
+                                                            ToolTip.Tip="Show filters">
+                                                            <i:Icon FontSize="12" Value="mdi-chevron-right" />
+                                                        </ToggleButton>
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            FontWeight="SemiBold"
+                                                            Opacity="0.9"
+                                                            Text="{Binding Scope}" />
+                                                    </DockPanel>
+                                                    <TextBlock
+                                                        Grid.Column="1"
+                                                        VerticalAlignment="Center"
+                                                        Opacity="0.9"
+                                                        TextAlignment="Right"
+                                                        Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                                                    <Border
+                                                        Grid.Column="2"
+                                                        Height="14"
+                                                        MinWidth="80"
+                                                        Margin="8,0"
+                                                        VerticalAlignment="Center"
+                                                        Background="#22FFFFFF"
+                                                        ClipToBounds="True"
+                                                        CornerRadius="4">
+                                                        <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <ItemsControl ItemsSource="{Binding Segments}">
+                                                                    <ItemsControl.ItemsPanel>
+                                                                        <ItemsPanelTemplate>
+                                                                            <StackPanel Orientation="Horizontal" />
+                                                                        </ItemsPanelTemplate>
+                                                                    </ItemsControl.ItemsPanel>
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate DataType="ts:BarSegment">
+                                                                            <Rectangle
+                                                                                Height="12"
+                                                                                Width="{Binding Hours}"
+                                                                                Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                                                                ToolTip.Tip="{Binding Filter}" />
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                                <Rectangle Height="12" Width="{Binding Remainder}" Fill="Transparent" />
+                                                            </StackPanel>
+                                                        </Viewbox>
+                                                    </Border>
+                                                </Grid>
+                                                <!-- The scope's filters (implicit template), shown when the scope is expanded. -->
+                                                <ItemsControl IsVisible="{Binding IsExpanded}" ItemsSource="{Binding Filters}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <!-- Single-scope target: its filters directly under it. -->
+                                <ItemsControl IsVisible="{Binding !CanExpand}" ItemsSource="{Binding Filters}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</UserControl>

--- a/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
+++ b/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
@@ -73,6 +73,27 @@
             Orientation="Horizontal"
             Spacing="8">
             <Button Command="{Binding RefreshCommand}" Content="Refresh" />
+            <TextBlock VerticalAlignment="Center" Text="Sort:" />
+            <ComboBox
+                MinWidth="160"
+                VerticalAlignment="Center"
+                ItemsSource="{Binding SortOptions}"
+                SelectedItem="{Binding SortBy}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Converter={x:Static converter:TargetSummarySortLabelConverter.Instance}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ToggleButton
+                VerticalAlignment="Center"
+                IsChecked="{Binding SortAscending}"
+                ToolTip.Tip="Ascending / descending">
+                <Panel>
+                    <i:Icon FontSize="16" IsVisible="{Binding SortAscending}" Value="mdi-sort-ascending" />
+                    <i:Icon FontSize="16" IsVisible="{Binding !SortAscending}" Value="mdi-sort-descending" />
+                </Panel>
+            </ToggleButton>
         </StackPanel>
 
         <ScrollViewer>

--- a/Lumidex/Features/TargetSummary/TargetSummaryView.axaml.cs
+++ b/Lumidex/Features/TargetSummary/TargetSummaryView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace Lumidex.Features.TargetSummary;
+
+public partial class TargetSummaryView : UserControl
+{
+    public TargetSummaryView() => InitializeComponent();
+}

--- a/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
@@ -1,0 +1,103 @@
+using Lumidex.Core.Targets;
+using Lumidex.Services;
+
+namespace Lumidex.Features.TargetSummary;
+
+public partial class TargetSummaryViewModel : ViewModelBase
+{
+    private readonly TargetResolutionService _resolution;
+    private readonly TargetSummaryQuery _query;
+    private readonly DialogService _dialogService;
+    // Serializes the DB-touching work so two reloads (e.g. fast Refresh clicks) don't resolve
+    // targets against the same SQLite file at once and hit SQLITE_BUSY.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    // Reassigned wholesale on each load; a fresh collection + one rebind avoids the ItemsControl
+    // range-notification crash the codebase hits when mutating in place.
+    [ObservableProperty] public partial ObservableCollectionEx<TargetRowViewModel> Targets { get; set; } = new();
+
+    public TargetSummaryViewModel(TargetResolutionService resolution, TargetSummaryQuery query, DialogService dialogService)
+    {
+        _resolution = resolution;
+        _query = query;
+        _dialogService = dialogService;
+    }
+
+    // Resolve names, aggregate, and rebuild the rows. async Task so a DB failure awaits a dialog
+    // instead of crashing the tab; preserves which targets/scopes were expanded.
+    public async Task Reload()
+    {
+        try
+        {
+            var expanded = Targets.Where(t => t.IsExpanded).Select(t => t.TargetId).ToHashSet();
+            var expandedScopes = Targets
+                .SelectMany(t => t.Scopes.Where(s => s.IsExpanded).Select(s => (t.TargetId, s.Scope)))
+                .ToHashSet();
+
+            var rows = await Task.Run(async () =>
+            {
+                await _gate.WaitAsync();
+                try
+                {
+                    _resolution.EnsureTargetsResolved();
+                    var built = _query.GetTargetSummary().Select(BuildRow).ToList();
+                    // Unset bars scale to the largest REAL target's hours; exclude the synthetic
+                    // "(Unnamed)" pile (TargetId 0), often the biggest, so real bars don't shrink
+                    // against junk. Push it onto every row so each bar computes off its own context.
+                    var max = built.Where(r => r.TargetId != 0).Select(r => r.Hours).DefaultIfEmpty(0).Max();
+                    foreach (var r in built)
+                    {
+                        r.ReferenceMax = max;
+                        foreach (var s in r.Scopes)
+                        {
+                            s.ReferenceMax = max;
+                            foreach (var f in s.Filters) f.ReferenceMax = max;
+                        }
+                    }
+                    return built;
+                }
+                finally { _gate.Release(); }
+            });
+
+            foreach (var r in rows)
+            {
+                r.IsExpanded = expanded.Contains(r.TargetId);
+                foreach (var s in r.Scopes)
+                    s.IsExpanded = expandedScopes.Contains((r.TargetId, s.Scope));
+            }
+            Targets = new(rows.OrderByDescending(r => r.Hours));
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to load the target summary");
+            try { await _dialogService.ShowMessageDialog("Failed to load the target summary."); }
+            catch (Exception dialogEx) { Log.Error(dialogEx, "Failed to show the target summary error dialog"); }
+        }
+    }
+
+    // Build a target row from the query result, ordering filters by name within each scope.
+    private static TargetRowViewModel BuildRow(TargetIntegration t)
+    {
+        var scopes = t.Scopes
+            .Select(s => new ScopeRowViewModel
+            {
+                Scope = s.Scope,
+                Filters = s.Filters
+                    .OrderBy(f => f.Filter, StringComparer.OrdinalIgnoreCase)
+                    .Select(f => new FilterRowViewModel { Filter = f.Filter, Hours = f.Hours })
+                    .ToList(),
+            })
+            .OrderBy(s => s.Scope, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return new TargetRowViewModel { TargetId = t.TargetId, CanonicalName = t.CanonicalName, Scopes = scopes };
+    }
+
+    protected override void OnInitialActivated()
+    {
+        base.OnInitialActivated();
+        _ = Reload();
+    }
+
+    [RelayCommand]
+    private Task Refresh() => Reload();
+}

--- a/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
@@ -3,6 +3,9 @@ using Lumidex.Services;
 
 namespace Lumidex.Features.TargetSummary;
 
+// The sort key for the target list.
+public enum TargetSummarySort { Alphabetical, DataAcquired, FirstAcquired, LastAcquired }
+
 public partial class TargetSummaryViewModel : ViewModelBase
 {
     private readonly TargetResolutionService _resolution;
@@ -15,6 +18,13 @@ public partial class TargetSummaryViewModel : ViewModelBase
     // Reassigned wholesale on each load; a fresh collection + one rebind avoids the ItemsControl
     // range-notification crash the codebase hits when mutating in place.
     [ObservableProperty] public partial ObservableCollectionEx<TargetRowViewModel> Targets { get; set; } = new();
+
+    // The sort control. Default is most-integrated first; changing either re-orders the loaded rows
+    // in memory (no DB hit).
+    [ObservableProperty] public partial TargetSummarySort SortBy { get; set; } = TargetSummarySort.DataAcquired;
+    [ObservableProperty] public partial bool SortAscending { get; set; } = false;
+
+    public IReadOnlyList<TargetSummarySort> SortOptions { get; } = Enum.GetValues<TargetSummarySort>();
 
     public TargetSummaryViewModel(TargetResolutionService resolution, TargetSummaryQuery query, DialogService dialogService)
     {
@@ -65,7 +75,7 @@ public partial class TargetSummaryViewModel : ViewModelBase
                 foreach (var s in r.Scopes)
                     s.IsExpanded = expandedScopes.Contains((r.TargetId, s.Scope));
             }
-            Targets = new(rows.OrderByDescending(r => r.Hours));
+            Targets = new(Order(rows));
         }
         catch (Exception ex)
         {
@@ -89,7 +99,7 @@ public partial class TargetSummaryViewModel : ViewModelBase
             })
             .OrderBy(s => s.Scope, StringComparer.OrdinalIgnoreCase)
             .ToList();
-        return new TargetRowViewModel { TargetId = t.TargetId, CanonicalName = t.CanonicalName, Scopes = scopes };
+        return new TargetRowViewModel { TargetId = t.TargetId, CanonicalName = t.CanonicalName, First = t.First, Last = t.Last, Scopes = scopes };
     }
 
     protected override void OnInitialActivated()
@@ -100,4 +110,33 @@ public partial class TargetSummaryViewModel : ViewModelBase
 
     [RelayCommand]
     private Task Refresh() => Reload();
+
+    partial void OnSortByChanged(TargetSummarySort value) => ApplySort();
+    partial void OnSortAscendingChanged(bool value) => ApplySort();
+
+    // Re-order the already-loaded rows without touching the DB. The same row instances are re-wrapped
+    // in a new collection, so expand state is preserved.
+    private void ApplySort()
+    {
+        if (Targets.Count > 0)
+            Targets = new(Order(Targets));
+    }
+
+    // Date keys push undated rows last (ascending) via MaxValue; the others compare their numeric or
+    // date key. Alphabetical compares case-insensitively.
+    private List<TargetRowViewModel> Order(IEnumerable<TargetRowViewModel> rows)
+    {
+        Func<TargetRowViewModel, IComparable> key = SortBy switch
+        {
+            TargetSummarySort.DataAcquired => r => r.Hours,
+            TargetSummarySort.FirstAcquired => r => r.First ?? DateTime.MaxValue,
+            TargetSummarySort.LastAcquired => r => r.Last ?? DateTime.MaxValue,
+            _ => r => r.CanonicalName,
+        };
+        var ordered = SortBy == TargetSummarySort.Alphabetical
+            ? rows.OrderBy(r => r.CanonicalName, StringComparer.OrdinalIgnoreCase)
+            : rows.OrderBy(key);
+        return (SortAscending ? ordered : ordered.Reverse()).ToList();
+    }
 }
+


### PR DESCRIPTION
## What?

A new Targets tab that shows every target in my library at a glance — its total
integration time, broken down by telescope and filter.

## Why?

One of my main frustrations with Lumidex has been that I can't just *look* at my
library and know what I have. I have to remember my aliases, run a search, and even
then I only see the one target I searched for. If I forget I imaged something, or
forget what I named it, I'm stuck going to the Aliases tab, guessing at searches and
hoping, or digging through folders outside Lumidex.

## How?

A new tab in the left-side navbar (a target icon) with a sortable list of every
target in my library, identified by its FITS OBJECT header name. If I have data on a
target from more than one telescope, I can expand it into a per-scope and then
per-filter breakdown. The bar on each row is a color-coded view of integration time
per filter, scaled against my most-integrated target so I can compare across targets
at a glance.

It also folds the many ways the same thing gets named into one row — targets like
M 80 / M80, Bode's / Bodes, horsehead / Horsehead, and filters like Ha / H or
Lum / L. The filter handling covers the standard imaging and photometric conventions
plus some less-standard ones (LRGB/SHO, UVBRI, L-Pro / L-Ultimate / L-eNhance), and
anything it doesn't recognize is shown as-is.

## Testing?

In addition to the automated tests Claude devised, I manually tested it on my own
library and worked through the issues I ran into. That said, I've only tested on
Fedora 44 KDE, not Windows or Mac.

## Anything Else?

I split this into commits where each piece can be taken or left on its own, so you
can pick and choose. It's the first of a few related PRs — per-filter integration
goals and a manual merge/split tool (for the cases the auto-folding gets wrong) will
follow as their own PRs. If you want to try it before committing to anything, I've
got a fork you can build from.
