### PR TITLE
Add a Target Summary Screen with Integration Time Per Scope/Filter, Minor Name-Normalization, and Reversible Merge

### DIFF
--- a/Lumidex.Core/Data/LumidexDbContext.cs
+++ b/Lumidex.Core/Data/LumidexDbContext.cs
@@ -27,6 +27,11 @@ public class LumidexDbContext : DbContext
     public DbSet<ObjectAlias> ObjectAliases { get; set; }
     public DbSet<AstrobinFilter> AstrobinFilters { get; set; }
     public DbSet<PersistedFilter> PersistedFilters { get; set; }
+    public DbSet<Target> Targets { get; set; }
+    public DbSet<TargetNameMap> TargetNameMaps { get; set; }
+    public DbSet<TargetFilterGoal> TargetFilterGoals { get; set; }
+    public DbSet<ScopeMerge> ScopeMerges { get; set; }
+    public DbSet<TargetMerge> TargetMerges { get; set; }
 
     public LumidexDbContext(DbContextOptions<LumidexDbContext> options)
         : base(options)
@@ -38,6 +43,12 @@ public class LumidexDbContext : DbContext
         modelBuilder.Entity<ImageFile>()
             .Property(x => x.CreatedOn)
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        // Target summary queries filter Type==Light then join/DISTINCT on ObjectName;
+        // without this the largest table is full-scanned thrice per reload. ObjectName is
+        // TEXT COLLATE NOCASE so the index inherits NOCASE and serves the case-insensitive join.
+        modelBuilder.Entity<ImageFile>()
+            .HasIndex(x => new { x.Type, x.ObjectName });
 
         modelBuilder.Entity<Library>()
             .Property(x => x.CreatedOn)

--- a/Lumidex.Core/Data/Migrations/20260702050912_AddTargetSummary.Designer.cs
+++ b/Lumidex.Core/Data/Migrations/20260702050912_AddTargetSummary.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lumidex.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumidex.Core.Data.Migrations
 {
     [DbContext(typeof(LumidexDbContext))]
-    partial class LumidexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702050912_AddTargetSummary")]
+    partial class AddTargetSummary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.5");

--- a/Lumidex.Core/Data/Migrations/20260702050912_AddTargetSummary.cs
+++ b/Lumidex.Core/Data/Migrations/20260702050912_AddTargetSummary.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumidex.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTargetSummary : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ScopeMerges",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    OperationId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CanonicalName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false),
+                    AbsorbedName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScopeMerges", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TargetMerges",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    OperationId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SurvivorTargetId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AbsorbedTargetId = table.Column<int>(type: "INTEGER", nullable: false),
+                    SurvivorLabel = table.Column<string>(type: "TEXT", nullable: false),
+                    AbsorbedLabel = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TargetMerges", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Targets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    CanonicalName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false),
+                    SimbadId = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: true),
+                    Ra = table.Column<double>(type: "REAL", nullable: true),
+                    Dec = table.Column<double>(type: "REAL", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Targets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TargetFilterGoals",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    TargetId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Scope = table.Column<string>(type: "TEXT", nullable: false),
+                    Filter = table.Column<string>(type: "TEXT", nullable: false),
+                    GoalHours = table.Column<double>(type: "REAL", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TargetFilterGoals", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TargetFilterGoals_Targets_TargetId",
+                        column: x => x.TargetId,
+                        principalTable: "Targets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TargetNameMaps",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    RawObjectName = table.Column<string>(type: "TEXT COLLATE NOCASE", nullable: false),
+                    TargetId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TargetNameMaps", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TargetNameMaps_Targets_TargetId",
+                        column: x => x.TargetId,
+                        principalTable: "Targets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageFiles_Type_ObjectName",
+                table: "ImageFiles",
+                columns: new[] { "Type", "ObjectName" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScopeMerges_AbsorbedName",
+                table: "ScopeMerges",
+                column: "AbsorbedName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetFilterGoals_TargetId_Scope_Filter",
+                table: "TargetFilterGoals",
+                columns: new[] { "TargetId", "Scope", "Filter" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetMerges_AbsorbedTargetId",
+                table: "TargetMerges",
+                column: "AbsorbedTargetId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetNameMaps_RawObjectName",
+                table: "TargetNameMaps",
+                column: "RawObjectName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TargetNameMaps_TargetId",
+                table: "TargetNameMaps",
+                column: "TargetId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScopeMerges");
+
+            migrationBuilder.DropTable(
+                name: "TargetFilterGoals");
+
+            migrationBuilder.DropTable(
+                name: "TargetMerges");
+
+            migrationBuilder.DropTable(
+                name: "TargetNameMaps");
+
+            migrationBuilder.DropTable(
+                name: "Targets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImageFiles_Type_ObjectName",
+                table: "ImageFiles");
+        }
+    }
+}

--- a/Lumidex.Core/Data/ScopeMerge.cs
+++ b/Lumidex.Core/Data/ScopeMerge.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumidex.Core.Data;
+
+// One absorbed-telescope-name -> canonical-name mapping from a user "Merge Scopes" action.
+// NON-DESTRUCTIVE: the frames keep their raw FITS TelescopeName; the fold is applied at query time
+// (TargetGoalQuery resolves scope names through these rows before the roll-up), so deleting the row
+// (Undo) re-separates the scopes with zero data loss. OperationId groups the rows of one merge
+// (folding three scopes into one writes two rows) so Undo reverses the whole action atomically.
+//
+// Names are NOCASE to match the FITS TelescopeName collation (the library logs "T20"/"t20"); the
+// resolver also lowercases its keys, so the read path and the de-dup guard agree on identity.
+//
+// AbsorbedName is UNIQUE — one survivor per absorbed name — the single-valued-map invariant the
+// resolver assumes. The application-level de-dup guard in MergeScopes enforces it within one process;
+// the unique index is the database backstop that catches a cross-instance race (it inherits the
+// column's NOCASE collation, so "T20"/"t20" count as the same absorbed name, matching the resolver).
+[Index(nameof(AbsorbedName), IsUnique = true)]
+public class ScopeMerge
+{
+    [Key]
+    public int Id { get; set; }
+
+    public Guid OperationId { get; set; }
+
+    // The kept spelling (survivor). New scope rows and goals roll up under this name.
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string CanonicalName { get; set; } = null!;
+
+    // The folded spelling. At most one ScopeMerge per AbsorbedName (enforced in MergeScopes) keeps
+    // the absorbed -> canonical remap single-valued.
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string AbsorbedName { get; set; } = null!;
+
+    public DateTime CreatedUtc { get; set; }
+}

--- a/Lumidex.Core/Data/Target.cs
+++ b/Lumidex.Core/Data/Target.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumidex.Core.Data;
+
+public class Target
+{
+    public int Id { get; set; }
+
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string CanonicalName { get; set; } = null!;
+
+    // Reserved for future SIMBAD / coordinate resolution; added nullable now so that
+    // work won't need a second migration. Unused so far.
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string? SimbadId { get; set; }
+    public double? Ra { get; set; }
+    public double? Dec { get; set; }
+
+    public ICollection<TargetNameMap> NameMaps { get; set; } = new List<TargetNameMap>();
+}

--- a/Lumidex.Core/Data/TargetFilterGoal.cs
+++ b/Lumidex.Core/Data/TargetFilterGoal.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Core.Data;
+
+// A per-(telescope, filter) integration goal in hours — the granularity goals are ENTERED at
+// in the Target Summary v2. Scope and Target goals are derived sums of their filter goals and
+// are never stored. (TargetId, Scope, Filter) is unique: one goal per filter per telescope per
+// target. Scope/Filter are the same strings the integration query buckets on — the FITS
+// TelescopeName and the canonical FilterName, or the "(Unknown scope)" / "(No filter)"
+// fallbacks.
+//
+// The FK to Target cascade-deletes by convention; the merge paths repoint goals onto the
+// survivor before deleting an absorbed target (TargetResolutionService.AbsorbInto) so a merge
+// does not cascade-drop them — keyed on (Scope, Filter) and de-duped case-insensitively, since
+// these columns are BINARY but their sources (TelescopeName / FilterName) are NOCASE.
+//
+// Scope and Filter are raw mutable strings, not ids: renaming a telescope or filter strands the
+// goal row under the old name (visible nowhere, recoverable only by editing the DB). A re-key
+// path is Phase B, not warranted while the feature carries no shipped data.
+[Index(nameof(TargetId), nameof(Scope), nameof(Filter), IsUnique = true)]
+public class TargetFilterGoal
+{
+    public int Id { get; set; }
+    public int TargetId { get; set; }
+    public Target Target { get; set; } = null!;
+    public string Scope { get; set; } = null!;
+    public string Filter { get; set; } = null!;
+    public double GoalHours { get; set; }
+}

--- a/Lumidex.Core/Data/TargetMerge.cs
+++ b/Lumidex.Core/Data/TargetMerge.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+
+namespace Lumidex.Core.Data;
+
+// One absorbed-target -> survivor-target mapping from a user "Merge Targets" action. NON-DESTRUCTIVE:
+// the absorbed Target row and its maps/goals are left intact; the fold is applied at query time, so
+// Undo (delete the row) restores it whole. OperationId groups one merge's rows for atomic undo. It is
+// non-destructive precisely to avoid the per-scope-goal cascade-loss a destructive merge would cause.
+//
+// DELIBERATELY NO foreign key to Target. ConsolidateFormattingVariants can delete a Target on any
+// reload; a Restrict FK would throw and a Cascade FK would silently un-merge. Plain ints + defensive
+// resolution (a dangling survivor id is skipped) decouple the record from the Target lifecycle.
+// Labels snapshot the names at merge time (the panel resolves the survivor's live name on top).
+//
+// AbsorbedTargetId is UNIQUE — one survivor per absorbed target — the single-valued-map invariant the
+// resolver assumes; the index is the DB backstop for the cross-instance race the in-process de-dup
+// guard can't cover.
+[Index(nameof(AbsorbedTargetId), IsUnique = true)]
+public class TargetMerge
+{
+    [Key]
+    public int Id { get; set; }
+
+    public Guid OperationId { get; set; }
+
+    public int SurvivorTargetId { get; set; }
+    public int AbsorbedTargetId { get; set; }
+
+    public string SurvivorLabel { get; set; } = null!;
+    public string AbsorbedLabel { get; set; } = null!;
+
+    public DateTime CreatedUtc { get; set; }
+}

--- a/Lumidex.Core/Data/TargetNameMap.cs
+++ b/Lumidex.Core/Data/TargetNameMap.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumidex.Core.Data;
+
+// One raw FITS-header OBJECT string maps to exactly one canonical Target.
+// RawObjectName is unique (NOCASE) and resolution trims it before keying, so
+// ASCII-case variants ("M 31"/"m 31") and whitespace-padded twins ("M 31 ")
+// collapse. The fold is ASCII-case + whitespace-trim only — non-ASCII case
+// variants (e.g. Greek/Cyrillic) are NOT folded, which is acceptable for the
+// numeric/Latin catalog designations FITS OBJECT carries in practice.
+[Index(nameof(RawObjectName), IsUnique = true)]
+public class TargetNameMap
+{
+    public int Id { get; set; }
+
+    [Column(TypeName = "TEXT COLLATE NOCASE")]
+    public string RawObjectName { get; set; } = null!;
+
+    public int TargetId { get; set; }
+    public Target Target { get; set; } = null!;
+}

--- a/Lumidex.Core/DependencyInjection.cs
+++ b/Lumidex.Core/DependencyInjection.cs
@@ -15,6 +15,10 @@ public static class DependencyInjection
     {
         services.AddTransient<IFileSystem, FileSystem>();
         services.AddTransient<LibraryIngestPipeline>();
+        // Not an IViewModelBase, so the UI auto-registration won't pick it up;
+        // register explicitly for injection into TargetSummaryViewModel.
+        services.AddTransient<Lumidex.Core.Targets.TargetResolutionService>();
+        services.AddTransient<Lumidex.Core.Targets.TargetGoalQuery>();
         services.AddTransient<Func<LibraryIngestPipeline>>(provider
             => () => provider.GetRequiredService<LibraryIngestPipeline>());
         

--- a/Lumidex.Core/Targets/FilterCanonicalizer.cs
+++ b/Lumidex.Core/Targets/FilterCanonicalizer.cs
@@ -1,0 +1,108 @@
+namespace Lumidex.Core.Targets;
+
+// Folds the many ways a filter gets named into one canonical label, so the
+// integration bars merge true synonyms (e.g. "H" and "Ha", or "Luminance" and
+// "L") into a single segment and color them consistently — while keeping
+// genuinely different filters apart.
+//
+// Two filter naming systems coexist in real libraries, and Lumidex serves both:
+//   - Imaging (astrophotography): Luminance, Red/Green/Blue (or L/R/G/B),
+//     narrowband Ha/OIII/SII/Hb/He/NII, one-shot-color "Color", and multiband
+//     LPro / L-eNhance / LUltimate.
+//   - Photometric (science): Johnson-Cousins U B V R I.
+//
+// The ONLY names that overlap between the two systems are the bare letters "B"
+// and "R". Everything else is unambiguous: "U", "V", "I" only exist in the
+// photometric system; "Luminance", "Green", the narrowband and multiband names,
+// and the colour words only exist in imaging. So the rule needs to resolve just
+// B and R, and it does so from context rather than special-casing any telescope:
+//
+//   A bare B/R is PHOTOMETRIC when the surrounding filter set shows photometric
+//   evidence — it contains U, V, or I (bands with no imaging meaning), OR it also
+//   carries the imaging WORD form (Blue/Red) of that colour, which means the bare
+//   letter must be the other system. Otherwise the letter is the imaging band.
+//
+// That one rule covers pure-imaging datasets (letters fold to LRGB), pure
+// photometry (UBVRI stays photometric), and mixed rigs that shoot both — with no
+// per-telescope exceptions. The disambiguation context is the telescope's whole
+// filter set (passed in by the caller), so a scope's B is classified the same way
+// for every target on it, not flipped by which filters a single target happens to
+// have.
+public static class FilterCanonicalizer
+{
+    // Unambiguous spelling variants → canonical label (case-insensitive, so only
+    // distinct spellings are listed here, not casings). The bare letters B and R
+    // are deliberately absent — they're resolved in Canonicalize by context.
+    private static readonly Dictionary<string, string> Direct = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["L"] = "L", ["Lum"] = "L", ["Luminance"] = "L",
+        ["Green"] = "Green", ["G"] = "Green",
+        ["Red"] = "Red",
+        ["Blue"] = "Blue",
+        ["Ha"] = "Ha", ["H"] = "Ha", ["Halpha"] = "Ha", ["H-alpha"] = "Ha", ["Hα"] = "Ha",
+        ["OIII"] = "OIII", ["O"] = "OIII", ["O3"] = "OIII",
+        ["SII"] = "SII", ["S"] = "SII", ["S2"] = "SII",
+        ["Hb"] = "Hb", ["Hbeta"] = "Hb", ["H-beta"] = "Hb", ["Hβ"] = "Hb",
+        ["He"] = "He", ["HeII"] = "He", ["HeI"] = "He",
+        ["NII"] = "NII", ["N"] = "NII", ["N2"] = "NII",
+        ["Color"] = "Color", ["Colour"] = "Color", ["OSC"] = "Color",
+        ["LPro"] = "LPro", ["L-Pro"] = "LPro",
+        ["LUltimate"] = "LUltimate", ["L-Ultimate"] = "LUltimate",
+        ["L-eNhance"] = "L-eNhance", ["LeNhance"] = "L-eNhance", ["L-Enhance"] = "L-eNhance", ["LEnhance"] = "L-eNhance",
+        ["U"] = "U", ["V"] = "V", ["I"] = "I", // photometric, unambiguous
+    };
+
+    // Maps one raw filter name to its canonical label. `datasetFilters` is the set
+    // of raw filter names that share this filter's disambiguation context (the
+    // telescope's whole filter set) — used only to resolve bare B/R. An empty or
+    // unrecognized name is returned unchanged (so "(No filter)" and any filter we
+    // don't know about pass through and color gray).
+    public static string Canonicalize(string? raw, IReadOnlyCollection<string> datasetFilters)
+    {
+        var name = (raw ?? string.Empty).Trim();
+        if (name.Length == 0)
+            return raw ?? string.Empty;
+
+        // Resolve the two ambiguous letters first, before the direct table.
+        if (name.Equals("B", StringComparison.OrdinalIgnoreCase))
+            return IsPhotometric("Blue", datasetFilters) ? "B" : "Blue";
+        if (name.Equals("R", StringComparison.OrdinalIgnoreCase))
+            return IsPhotometric("Red", datasetFilters) ? "R" : "Red";
+
+        return Direct.TryGetValue(name, out var canonical) ? canonical : name;
+    }
+
+    // The four canonical labels whose resolution is context-DEPENDENT: a bare B/R flips
+    // between the photometric letter ("B"/"R") and the imaging word ("Blue"/"Red") when the
+    // scope's filter set changes — a photometric run landing on the rig, or a scope merge,
+    // is enough. Every other label canonicalizes the same way in every context. Goal
+    // persistence uses this map to keep a stored goal attached to its channel across a
+    // flip: the label a goal was saved under may be the partner of the label the same
+    // cell renders today. Returns null for the non-flippable labels.
+    public static string? FlipPartnerOf(string canonicalLabel) => canonicalLabel.ToLowerInvariant() switch
+    {
+        "b" => "Blue",
+        "blue" => "B",
+        "r" => "Red",
+        "red" => "R",
+        _ => null,
+    };
+
+    // Photometric evidence for a bare letter: the dataset carries a
+    // Johnson-Cousins-only band (U/V/I), or it carries the imaging word-form of the
+    // same colour alongside the letter (so the letter must be the other system).
+    private static bool IsPhotometric(string imagingWord, IReadOnlyCollection<string> datasetFilters)
+    {
+        foreach (var f in datasetFilters)
+        {
+            var t = f.Trim();
+            if (t.Equals("U", StringComparison.OrdinalIgnoreCase)
+                || t.Equals("V", StringComparison.OrdinalIgnoreCase)
+                || t.Equals("I", StringComparison.OrdinalIgnoreCase)
+                || t.Equals(imagingWord, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Lumidex.Core/Targets/FilterClassifier.cs
+++ b/Lumidex.Core/Targets/FilterClassifier.cs
@@ -1,0 +1,125 @@
+using System.Text.RegularExpressions;
+
+namespace Lumidex.Core.Targets;
+
+// Which naming system a filter belongs to. The Target Summary renders filter segments in
+// this band order (Broadband first), then by wavelength within a band — so a filter Lumidex
+// has never seen still lands in the right section automatically, with no per-filter entry.
+public enum FilterBand
+{
+    Broadband = 0,    // L, Red, Green, Blue
+    Narrowband = 1,   // Ha, OIII, SII, NII, Hb, He, ... (emission lines)
+    Photometric = 2,  // Johnson-Cousins U B V R I, Sloan u' g' r' i' z'
+    OscMultiband = 3, // one-shot colour + dual/tri-band (L-eNhance, L-Ultimate, ...)
+    Unknown = 4,
+}
+
+// Classifies a filter and produces a stable sort key, by RULE (naming conventions +
+// physics), no hard-coded master list and no ML. Dustin's requirement: determine a filter's
+// type and slot it in automatically rather than enumerate every filter imaginable.
+//
+// The input is the FilterCanonicalizer label. For filters the canonicalizer knows, that's a
+// clean label ("Ha", "V", ...); for ones it doesn't, the canonicalizer returns the raw FITS
+// name unchanged, so the same string still carries the tokens/bandwidth we pattern-match on.
+public static partial class FilterClassifier
+{
+    // Approx central wavelength (nm) per known label — used only to ORDER within a band, not
+    // to identify filters. Physics, deliberately short: an unknown filter takes a wavelength
+    // from an embedded "NNNnm" if present, else sorts to its band's tail.
+    private static readonly Dictionary<string, double> Wavelength = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Red"] = 610, ["Green"] = 530, ["Blue"] = 470,                  // broadband colour
+        ["SII"] = 672, ["NII"] = 658, ["Ha"] = 656, ["OIII"] = 500,       // narrowband ...
+        ["Hb"] = 486, ["He"] = 468, ["OII"] = 372,                       // ... emission lines
+        ["U"] = 365, ["B"] = 445, ["V"] = 551, ["R"] = 658, ["I"] = 806,  // Johnson-Cousins
+    };
+
+    // Canonical labels grouped by band (the set FilterCanonicalizer can produce).
+    private static readonly HashSet<string> BroadbandLabels = new(StringComparer.OrdinalIgnoreCase) { "L", "Red", "Green", "Blue" };
+    private static readonly HashSet<string> PhotometricLabels = new(StringComparer.OrdinalIgnoreCase) { "U", "B", "V", "R", "I" };
+    private static readonly HashSet<string> NarrowbandLabels = new(StringComparer.OrdinalIgnoreCase) { "SII", "Ha", "OIII", "NII", "Hb", "He", "OII" };
+    // OSC/multiband, in display order; the index is the within-band rank.
+    private static readonly string[] OscOrder = { "Color", "L-eNhance", "L-Ultimate", "LPro" };
+    // Hubble-palette trio, pinned ahead of the rest of the narrowband band: keep SHO visually
+    // grouped rather than let NII's 658 nm split it under pure wavelength-descending order.
+    private static readonly string[] ShoLead = { "SII", "Ha", "OIII" };
+
+    private const double Tail = 1e6;   // parks an unknown-wavelength filter at its band's tail
+
+    [GeneratedRegex(@"(\d+(?:\.\d+)?)\s*nm", RegexOptions.IgnoreCase)] private static partial Regex NmRegex();
+    [GeneratedRegex(@"^[ugriz]'?$", RegexOptions.IgnoreCase)] private static partial Regex SloanRegex();
+    // Emission-line tokens marking an unknown name narrowband. Anchored with \b (word START)
+    // so a token matches at a word boundary — "HeII"/"Halpha" still match, but a token that is
+    // only a mid-word substring (the "he" in "Sheet") does not, avoiding false narrowband hits.
+    [GeneratedRegex(@"\b(Halpha|OIII|SII|NII|Hbeta|Ha|Hb|OII|He|NV|CIV)", RegexOptions.IgnoreCase)] private static partial Regex NbTokenRegex();
+    // Dual/tri-band & OSC keywords, same word-boundary guard.
+    [GeneratedRegex(@"\b(OSC|Colou?r|Duo|Tri|Quad|UHC|CLS|eNhance|Ultimate|L-?Pro)", RegexOptions.IgnoreCase)] private static partial Regex OscTokenRegex();
+
+    // The band a filter belongs to. `filter` is the FilterCanonicalizer label (= the raw FITS
+    // name for filters the canonicalizer didn't fold, which is what the pattern fallbacks read).
+    public static FilterBand BandOf(string filter)
+    {
+        var name = (filter ?? string.Empty).Trim();
+        if (BroadbandLabels.Contains(name)) return FilterBand.Broadband;
+        if (PhotometricLabels.Contains(name)) return FilterBand.Photometric;
+        if (NarrowbandLabels.Contains(name)) return FilterBand.Narrowband;
+        if (OscOrder.Contains(name, StringComparer.OrdinalIgnoreCase)) return FilterBand.OscMultiband;
+
+        // Unrecognised label → pattern recognition on the (raw) name. Order matters: Sloan and
+        // OSC keywords are checked before the broader narrowband token scan.
+        if (SloanRegex().IsMatch(name)) return FilterBand.Photometric;
+        if (OscTokenRegex().IsMatch(name)) return FilterBand.OscMultiband;
+        if (NbTokenRegex().IsMatch(name)) return FilterBand.Narrowband;
+        // A narrow bandwidth (<= ~12 nm) embedded in the name marks narrowband.
+        var m = NmRegex().Match(name);
+        if (m.Success && double.TryParse(m.Groups[1].Value, out var nm) && nm <= 12) return FilterBand.Narrowband;
+
+        return FilterBand.Unknown;
+    }
+
+    // A comparable sort key. Sorting ASCENDING gives: bands in fixed order, then within a band
+    // — broadband L-first then R/G/B by wavelength DESCENDING; narrowband by wavelength
+    // DESCENDING (Hubble convention); photometric by wavelength ASCENDING (catalog
+    // convention); OSC by its curated order; unknown filters alphabetical and last. The final
+    // element breaks ties by label so the order is stable.
+    public static (int Band, double Within, string Tie) SortKey(string filter)
+    {
+        var name = (filter ?? string.Empty).Trim();
+        var band = BandOf(name);
+        double? nm = WavelengthOf(name);
+        double within = band switch
+        {
+            FilterBand.Broadband => name.Equals("L", StringComparison.OrdinalIgnoreCase)
+                ? double.MinValue                       // L (panchromatic) pinned first
+                : (nm is double w ? -w : Tail),         // R/G/B descending; unknown last
+            FilterBand.Narrowband => ShoIndex(name) is double s ? -1e6 + s   // SHO pinned first (S-H-O)
+                : nm is double n ? -n : Tail,                                // then the rest, wavelength desc; unknown last
+            FilterBand.Photometric => nm ?? Tail,                  // ascending; unknown last
+            FilterBand.OscMultiband => OscIndex(name),
+            _ => 0,
+        };
+        return ((int)band, within, name);
+    }
+
+    // Wavelength for ordering: the known table, else an embedded "NNNnm", else null (tail).
+    private static double? WavelengthOf(string name)
+    {
+        if (Wavelength.TryGetValue(name, out var nm)) return nm;
+        var m = NmRegex().Match(name);
+        return m.Success && double.TryParse(m.Groups[1].Value, out var parsed) ? parsed : null;
+    }
+
+    private static double OscIndex(string name)
+    {
+        var i = Array.FindIndex(OscOrder, o => o.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return i >= 0 ? i : OscOrder.Length;   // an unknown OSC keyword sorts after the curated ones
+    }
+
+    // Index of a Hubble-palette filter (SII, Ha, OIII) so it pins ahead of the NB tail in
+    // S-H-O order; null for any other narrowband filter (which then sorts by wavelength).
+    private static double? ShoIndex(string name)
+    {
+        var i = Array.FindIndex(ShoLead, x => x.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return i >= 0 ? i : null;
+    }
+}

--- a/Lumidex.Core/Targets/MergeResolver.cs
+++ b/Lumidex.Core/Targets/MergeResolver.cs
@@ -1,0 +1,93 @@
+using Lumidex.Core.Data;
+
+namespace Lumidex.Core.Targets;
+
+// Which kind of thing a user merge folded — drives the icon/label in the Manage-merges panel.
+public enum MergeKind { Scope, Target }
+
+// One user merge action, flattened for the Manage-merges panel: the survivor it kept and the names
+// it absorbed. OperationId is the handle Undo passes back to TargetResolutionService.UndoMerge.
+public record MergeOperation(
+    Guid OperationId,
+    MergeKind Kind,
+    string SurvivorLabel,
+    IReadOnlyList<string> AbsorbedLabels,
+    DateTime CreatedUtc);
+
+// Turns the stored merge records into the absorbed -> survivor lookups the query applies in memory
+// before the roll-up. The maps are TRANSITIVE (A->B plus B->C resolves A->C, which happens when a
+// survivor is later re-merged into a newer canonical). A record set that loops back on itself (a
+// cycle) has no terminal survivor; such keys are OMITTED from the map — their rows simply show
+// un-folded — rather than throwing, so a corrupt or cyclic set can never brick the reload. A cycle
+// is unreachable through the UI (an absorbed row folds away and can't be re-selected); this totality
+// is the safety net for any that a future caller or an odd consolidation sequence might produce.
+// Pure (no DB) so the resolution logic is unit-testable on its own.
+public static class MergeResolver
+{
+    // A real fold depth is 1-2; a chain longer than this is a cycle or corruption, not a deeper
+    // merge. The bound makes the resolve loop terminate on a cyclic set instead of looping forever.
+    private const int MaxChain = 32;
+
+    // absorbed TelescopeName (lowercased) -> terminal canonical name. Scope names compare
+    // case-insensitively (the library logs "T20"/"t20"); the query lowercases its scope keys too.
+    public static IReadOnlyDictionary<string, string> BuildScopeMap(IEnumerable<ScopeMerge> merges)
+    {
+        var direct = new Dictionary<string, string>();
+        foreach (var m in merges)
+            direct[m.AbsorbedName.ToLowerInvariant()] = m.CanonicalName;
+
+        var resolved = new Dictionary<string, string>();
+        foreach (var absorbed in direct.Keys)
+            if (TryResolveString(direct, absorbed, out var terminal))
+                resolved[absorbed] = terminal;   // a cyclic key is omitted -> its row shows un-folded
+        return resolved;
+    }
+
+    // absorbed TargetId -> terminal survivor id.
+    public static IReadOnlyDictionary<int, int> BuildTargetMap(IEnumerable<TargetMerge> merges)
+    {
+        var direct = new Dictionary<int, int>();
+        foreach (var m in merges)
+            direct[m.AbsorbedTargetId] = m.SurvivorTargetId;
+
+        var resolved = new Dictionary<int, int>();
+        foreach (var absorbed in direct.Keys)
+            if (TryResolveInt(direct, absorbed, out var terminal))
+                resolved[absorbed] = terminal;
+        return resolved;
+    }
+
+    // Follow direct[start] until the value is not itself an absorbed key (the terminal survivor).
+    // Returns false if the chain exceeds MaxChain (a cycle), so the caller omits the key.
+    private static bool TryResolveString(IReadOnlyDictionary<string, string> direct, string startKey, out string terminal)
+    {
+        var current = direct[startKey];
+        for (var hops = 0; hops < MaxChain; hops++)
+        {
+            if (!direct.TryGetValue(current.ToLowerInvariant(), out var next))
+            {
+                terminal = current;
+                return true;
+            }
+            current = next;
+        }
+        terminal = current;
+        return false;
+    }
+
+    private static bool TryResolveInt(IReadOnlyDictionary<int, int> direct, int startKey, out int terminal)
+    {
+        var current = direct[startKey];
+        for (var hops = 0; hops < MaxChain; hops++)
+        {
+            if (!direct.TryGetValue(current, out var next))
+            {
+                terminal = current;
+                return true;
+            }
+            current = next;
+        }
+        terminal = current;
+        return false;
+    }
+}

--- a/Lumidex.Core/Targets/TargetGoalQuery.cs
+++ b/Lumidex.Core/Targets/TargetGoalQuery.cs
@@ -1,0 +1,210 @@
+using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Core.Targets;
+
+// One filter's integration on one scope. Hours = acquired; ExplicitGoal = the stored goal or
+// null when unset; First/Last = the earliest/latest frame's observation time (for date sorts).
+public record FilterGoal(string Filter, double Hours, double? ExplicitGoal, DateTime? First, DateTime? Last)
+{
+    // Goals v2 enters goals only on filters; an UNSET filter's goal defaults to its current
+    // acquired hours, so it reads 100% and contributes its actual to the rolled-up goal.
+    public double EffectiveGoal => ExplicitGoal ?? Hours;
+}
+
+// One scope (telescope) on a target. Hours and Goal are derived sums of its filters, so they
+// stay consistent by construction; First/Last span its filters.
+public record ScopeGoal(string Scope, DateTime? First, DateTime? Last, IReadOnlyList<FilterGoal> Filters)
+{
+    public double Hours => Filters.Sum(f => f.Hours);
+    public double Goal => Filters.Sum(f => f.EffectiveGoal);
+}
+
+// One canonical target. Hours and Goal are derived sums of its scopes; First/Last span them.
+public record TargetGoal(int TargetId, string CanonicalName, DateTime? First, DateTime? Last, IReadOnlyList<ScopeGoal> Scopes)
+{
+    public double Hours => Scopes.Sum(s => s.Hours);
+    public double Goal => Scopes.Sum(s => s.Goal);
+}
+
+// Aggregates Light-frame integration target -> scope -> filter, attaches the per-filter goal
+// (from TargetFilterGoals), and rolls scope/target goals up as derived sums. Returns the tree
+// UNORDERED — sorting is a per-layer view concern (the summary's sort control); filter rows get
+// the FilterClassifier's static order in the view.
+public class TargetGoalQuery
+{
+    private const string UnknownScope = "(Unknown scope)";
+    private const string NoFilter = "(No filter)";
+    private const string Unnamed = "(Unnamed)";
+
+    private static readonly HashSet<string> EmptyScopeFilters = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+    public TargetGoalQuery(IDbContextFactory<LumidexDbContext> dbContextFactory)
+        => _dbContextFactory = dbContextFactory;
+
+    private record Cell(int Id, string Name, string Scope, string Filter, double Hours, DateTime? First, DateTime? Last);
+
+    public IReadOnlyList<TargetGoal> GetTargetGoals()
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+
+        // Active user merges (non-destructive): absorbed -> survivor lookups applied in memory
+        // before the roll-up, so a merged scope/target folds into its survivor with no physical
+        // delete (Undo just removes the record). See MergeResolver.
+        // The merge tables are read whole each reload — one row per absorbed name/id (tens at most),
+        // so a full read beats any lookup index; their only index is the UNIQUE integrity constraint.
+        var scopeMap = MergeResolver.BuildScopeMap(db.ScopeMerges.AsNoTracking().ToList());
+        var targetMap = MergeResolver.BuildTargetMap(db.TargetMerges.AsNoTracking().ToList());
+        var targetNames = db.Targets.AsNoTracking()
+            .Select(t => new { t.Id, t.CanonicalName })
+            .AsEnumerable()
+            .ToDictionary(t => t.Id, t => t.CanonicalName);
+        // A scope fold maps any cell's scope; a target fold maps only real targets (id 0 is the
+        // synthetic "(Unnamed)" pile) and a survivor deleted by auto-consolidation is skipped.
+        string ResolveScope(string scope) =>
+            scopeMap.TryGetValue(scope.ToLowerInvariant(), out var canon) ? canon : scope;
+        int ResolveTarget(int id) =>
+            id != 0 && targetMap.TryGetValue(id, out var sid) && targetNames.ContainsKey(sid) ? sid : id;
+
+        // (target, scope, filter) -> seconds + date extents, over Light frames with a mapped
+        // name. Trim the ObjectName on the join so a space-padded twin matches the stored map.
+        var flat = (from f in db.ImageFiles.AsNoTracking()
+                    where f.Type == ImageType.Light
+                    join m in db.TargetNameMaps on f.ObjectName!.Trim() equals m.RawObjectName
+                    join t in db.Targets on m.TargetId equals t.Id
+                    group f by new { t.Id, t.CanonicalName, f.TelescopeName, f.FilterName } into g
+                    select new
+                    {
+                        g.Key.Id, g.Key.CanonicalName, g.Key.TelescopeName, g.Key.FilterName,
+                        Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                        First = g.Min(x => x.ObservationTimestampUtc),
+                        Last = g.Max(x => x.ObservationTimestampUtc),
+                    }).ToList();
+
+        // Light frames with no usable ObjectName -> synthetic "(Unnamed)".
+        var unnamed = (from f in db.ImageFiles.AsNoTracking()
+                       where f.Type == ImageType.Light && (f.ObjectName == null || f.ObjectName!.Trim() == "")
+                       group f by new { f.TelescopeName, f.FilterName } into g
+                       select new
+                       {
+                           g.Key.TelescopeName, g.Key.FilterName,
+                           Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                           First = g.Min(x => x.ObservationTimestampUtc),
+                           Last = g.Max(x => x.ObservationTimestampUtc),
+                       }).ToList();
+
+        // Light frames named but unmapped -> a self-named synthetic row, so their hours still count.
+        var unmapped = (from f in db.ImageFiles.AsNoTracking()
+                        where f.Type == ImageType.Light && f.ObjectName != null && f.ObjectName!.Trim() != ""
+                              && !db.TargetNameMaps.Any(m => m.RawObjectName == f.ObjectName!.Trim())
+                        group f by new { ObjectName = f.ObjectName!.Trim(), f.TelescopeName, f.FilterName } into g
+                        select new
+                        {
+                            g.Key.ObjectName, g.Key.TelescopeName, g.Key.FilterName,
+                            Seconds = g.Sum(x => (double?)x.Exposure) ?? 0.0,
+                            First = g.Min(x => x.ObservationTimestampUtc),
+                            Last = g.Max(x => x.ObservationTimestampUtc),
+                        }).ToList();
+
+        var cells = flat.Select(x => ToCell(x.Id, x.CanonicalName, x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last))
+            .Concat(unnamed.Select(x => ToCell(0, Unnamed, x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last)))
+            // A whitespace-only unmapped name folds to "(Unnamed)" (the SQL predicate can't catch tabs).
+            .Concat(unmapped.Select(x => ToCell(0, string.IsNullOrWhiteSpace(x.ObjectName) ? Unnamed : x.ObjectName!,
+                                                x.TelescopeName, x.FilterName, x.Seconds, x.First, x.Last)))
+            .ToList();
+
+        // Fold absorbed scope names + target ids onto their survivors before anything groups on
+        // them. A remapped cell takes the survivor's canonical name (guaranteed present, since
+        // ResolveTarget only returns an id that exists in targetNames).
+        cells = cells.Select(c =>
+        {
+            var id = ResolveTarget(c.Id);
+            return c with { Id = id, Name = id != c.Id ? targetNames[id] : c.Name, Scope = ResolveScope(c.Scope) };
+        }).ToList();
+
+        // Canonicalize each cell's filter (per-scope context for the bare-B/R rule), so true
+        // synonyms merge before the roll-up groups by filter.
+        var scopeFilters = cells
+            .GroupBy(c => c.Scope)
+            .ToDictionary(g => g.Key, g => g.Select(c => c.Filter).ToHashSet(StringComparer.OrdinalIgnoreCase));
+        var canonical = cells.Select(c => c with
+        {
+            Filter = FilterCanonicalizer.Canonicalize(c.Filter,
+                scopeFilters.TryGetValue(c.Scope, out var sf) ? sf : EmptyScopeFilters),
+        });
+
+        // Explicit per-(target, scope, filter) goals, keyed case-INSENSITIVELY (BINARY columns,
+        // NOCASE sources — see AbsorbInto for the full collation rationale).
+        // A goal stored under an absorbed target/scope must key under the survivor so it rolls up on
+        // the merged row; apply the SAME ResolveScope/ResolveTarget the cell fold above uses. KEEP
+        // THE TWO IN SYNC — if a future change remaps cells differently, remap goals the same way or
+        // goals land on the wrong row (GetTargetGoals_ScopeMerge_GoalUnderAbsorbedScope... guards it).
+        // GroupBy+Max picks the larger when both merged sides set a goal for the same filter.
+        var goals = db.TargetFilterGoals.AsNoTracking()
+            .Select(g => new { g.TargetId, g.Scope, g.Filter, g.GoalHours })
+            .AsEnumerable()
+            .GroupBy(g => (TargetId: ResolveTarget(g.TargetId), Scope: ResolveScope(g.Scope).ToLowerInvariant(), Filter: g.Filter.ToLowerInvariant()))
+            .ToDictionary(g => g.Key, g => g.Max(x => x.GoalHours));
+
+        return RollUp(canonical, goals);
+    }
+
+    private static Cell ToCell(int id, string name, string? telescopeName, string? filterName, double seconds, DateTime? first, DateTime? last)
+        => new(id, name,
+            string.IsNullOrEmpty(telescopeName) ? UnknownScope : telescopeName,
+            string.IsNullOrEmpty(filterName) ? NoFilter : filterName,
+            seconds / 3600.0, first, last);
+
+    private static IReadOnlyList<TargetGoal> RollUp(
+        IEnumerable<Cell> cells,
+        IReadOnlyDictionary<(int TargetId, string Scope, string Filter), double> goals)
+    {
+        return cells
+            .GroupBy(c => (c.Id, c.Name))
+            .Select(tg =>
+            {
+                var scopes = tg.GroupBy(c => c.Scope)
+                    .Select(sg =>
+                    {
+                        var scopeKey = sg.Key.ToLowerInvariant();
+                        // The scope's rendered (canonical) filter labels — the guard for the
+                        // bare-B/R flip fallback in LookupGoal below.
+                        var cellFilters = sg.Select(c => c.Filter).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                        var filters = sg.GroupBy(c => c.Filter)
+                            .Select(fg => new FilterGoal(
+                                fg.Key,
+                                fg.Sum(c => c.Hours),
+                                LookupGoal(goals, tg.Key.Id, scopeKey, fg.Key, cellFilters),
+                                fg.Min(c => c.First),   // Min over DateTime? ignores nulls, null when all null
+                                fg.Max(c => c.Last)))
+                            .ToList();
+                        return new ScopeGoal(sg.Key, filters.Min(f => f.First), filters.Max(f => f.Last), filters);
+                    })
+                    .ToList();
+                return new TargetGoal(tg.Key.Id, tg.Key.Name, scopes.Min(s => s.First), scopes.Max(s => s.Last), scopes);
+            })
+            .ToList();
+    }
+
+    // Case-insensitive goal lookup: exact key first, then the bare-B/R flip partner. A goal is
+    // stored under the CANONICAL label at save time, but bare B/R canonicalize from the scope's
+    // whole filter set — so a photometric run landing (or a scope merge) relabels the cell
+    // ("Blue" -> "B") and the stored goal would silently stop matching. The partner lookup keeps
+    // it attached. Guard: only borrow when the partner label has no cell of its own in this
+    // target's scope group (goal keys include the TargetId, so only same-target cells could
+    // ever double-attach) — when a scope legitimately shows BOTH (raw word "Blue" beside a
+    // photometric bare "B"), the partner-labelled goal belongs to that other cell, and
+    // borrowing it would show and roll up the same goal twice.
+    private static double? LookupGoal(
+        IReadOnlyDictionary<(int TargetId, string Scope, string Filter), double> goals,
+        int targetId, string scopeKey, string filter, IReadOnlySet<string> scopeCellFilters)
+    {
+        if (goals.TryGetValue((targetId, scopeKey, filter.ToLowerInvariant()), out var goal))
+            return goal;
+        return FilterCanonicalizer.FlipPartnerOf(filter) is { } partner
+            && !scopeCellFilters.Contains(partner)
+            && goals.TryGetValue((targetId, scopeKey, partner.ToLowerInvariant()), out var flipped)
+            ? flipped : null;
+    }
+}

--- a/Lumidex.Core/Targets/TargetResolutionService.cs
+++ b/Lumidex.Core/Targets/TargetResolutionService.cs
@@ -1,0 +1,369 @@
+using Lumidex.Core.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+
+namespace Lumidex.Core.Targets;
+
+// Canonical-identity maintenance for the target summary. Phase A: deterministic,
+// no network. Maps each FITS-header ObjectName to a Target, folding pure FORMATTING
+// variants of a name (case / whitespace / punctuation) onto one Target, and merges
+// targets on user request. Cross-catalog identity (e.g. "Tarantula Nebula" == "NGC
+// 2070") and the display naming convention are out of scope here — they need catalog
+// resolution (Phase B).
+public class TargetResolutionService
+{
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+
+    public TargetResolutionService(IDbContextFactory<LumidexDbContext> dbContextFactory)
+        => _dbContextFactory = dbContextFactory;
+
+    // Resolve targets in two passes: first collapse any existing formatting-variant
+    // duplicates (e.g. separate "NGC 2070" / "Ngc2070" targets from an earlier 1:1
+    // run), then map any not-yet-mapped ObjectNames. Idempotent — a second call finds
+    // nothing to merge and nothing new to add.
+    public void EnsureTargetsResolved()
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+        ConsolidateFormattingVariants(db);
+        MapNewObjectNames(db);
+    }
+
+    // Light identity key: lowercase, alphanumerics only. Collapses the formatting
+    // variants of a name — "Bode's Galaxy"/"Bodes Galaxy", "NGC 2070"/"Ngc2070",
+    // "M 101"/"M101" — to one key. It does NOT understand catalog cross-references
+    // (it cannot know "Tarantula Nebula" == "NGC 2070"); names that differ by real
+    // words stay distinct. Returns "" for a name with no alphanumerics.
+    //
+    // Knowingly lossy and not re-splittable: stripping every non-alphanumeric also folds
+    // hyphenated catalog designations ("M1-67" and "M167" collapse to one key). A
+    // hyphen-significance rule would re-fragment the "M 101"/"M101" formatting variants this
+    // exists to merge, so it is accepted for Phase A; true catalog identity is Phase B.
+    private static string NormalizeKey(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+
+    // Merge targets whose names share a NormalizeKey into the one with the most Light
+    // frames (the dominant spelling), so a single object that was split across spelling
+    // variants shows as one row. Reuses the same repoint-before-delete ordering as
+    // MergeTargets so no name map is cascade-dropped. No-op once the library is clean.
+    private static void ConsolidateFormattingVariants(LumidexDbContext db)
+    {
+        var keyed = db.TargetNameMaps
+            .Select(m => new { m.RawObjectName, m.TargetId })
+            .AsEnumerable()
+            .Select(m => new { Key = NormalizeKey(m.RawObjectName), m.TargetId })
+            .Where(m => m.Key.Length > 0)
+            .ToList();
+
+        var groups = keyed
+            .GroupBy(m => m.Key)
+            .Where(g => g.Select(m => m.TargetId).Distinct().Count() > 1)
+            .ToList();
+        if (groups.Count == 0)
+            return;
+
+        var frames = FrameCountsByTarget(db);
+        foreach (var g in groups)
+        {
+            var ids = g.Select(m => m.TargetId).Distinct().ToList();
+            // Survivor = most Light frames; ties fall to the smallest id for determinism.
+            var survivorId = ids
+                .OrderByDescending(id => frames.GetValueOrDefault(id))
+                .ThenBy(id => id)
+                .First();
+            AbsorbInto(db, survivorId, ids.Where(id => id != survivorId).ToList());
+        }
+
+        db.SaveChanges();
+    }
+
+    // Map every distinct non-empty ObjectName to a Target. A name whose NormalizeKey
+    // already belongs to a target joins it (a new map, no new target); otherwise it
+    // mints a new target. Idempotent — only names not already mapped are added.
+    private static void MapNewObjectNames(LumidexDbContext db)
+    {
+        var maps = db.TargetNameMaps
+            .Select(m => new { m.RawObjectName, m.TargetId })
+            .AsEnumerable()
+            // Trim the stored key so the idempotency check matches trimmed names.
+            .Select(m => new { Raw = m.RawObjectName.Trim(), m.TargetId })
+            .ToList();
+
+        var mappedRaw = maps.Select(m => m.Raw).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var keyToTarget = maps
+            // Compute the identity key once per name instead of in both the filter and
+            // the group-by that follow.
+            .Select(m => new { m.Raw, Key = NormalizeKey(m.Raw), m.TargetId })
+            .Where(m => m.Key.Length > 0)
+            .GroupBy(m => m.Key)
+            // Post-consolidation there is one target per key; First() is safe.
+            .ToDictionary(g => g.Key, g => g.First().TargetId);
+
+        var names = db.ImageFiles
+            .Where(f => f.ObjectName != null && f.ObjectName != "")
+            .Select(f => f.ObjectName!)
+            .Distinct()
+            .ToList()
+            // Whitespace-only names ("   ", "\t") spawn no target — symmetric with
+            // MergeTargets' ThrowIfNullOrWhiteSpace. Client-side because SQLite TRIM
+            // strips only spaces, not tabs/newlines.
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            // FITS space-pads OBJECT, so "M 31" and "M 31 " arrive distinct; trim to one
+            // identity. The integration-query join trims the same way, so maps still match.
+            .Select(n => n.Trim())
+            .Distinct()
+            .ToList();
+
+        // Targets minted earlier in THIS loop, so a second new variant of the same key
+        // joins the pending target instead of minting a duplicate before SaveChanges.
+        var pendingByKey = new Dictionary<string, Target>(StringComparer.Ordinal);
+        var added = false;
+
+        foreach (var name in names)
+        {
+            if (!mappedRaw.Add(name))
+                continue; // already mapped (case-insensitive)
+
+            var key = NormalizeKey(name);
+            if (key.Length > 0 && keyToTarget.TryGetValue(key, out var existingId))
+            {
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, TargetId = existingId });
+            }
+            else if (key.Length > 0 && pendingByKey.TryGetValue(key, out var pending))
+            {
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = pending });
+            }
+            else
+            {
+                var target = new Target { CanonicalName = name };
+                db.Targets.Add(target);
+                db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = name, Target = target });
+                if (key.Length > 0)
+                    pendingByKey[key] = target;
+            }
+            added = true;
+        }
+
+        if (added)
+            db.SaveChanges();
+    }
+
+    // Light-frame count per target, via the trimmed name-map join (mirroring the
+    // integration query), so the consolidation survivor is the dominant spelling.
+    private static Dictionary<int, int> FrameCountsByTarget(LumidexDbContext db)
+    {
+        return (from f in db.ImageFiles
+                where f.Type == ImageType.Light && f.ObjectName != null && f.ObjectName != ""
+                join m in db.TargetNameMaps on f.ObjectName!.Trim() equals m.RawObjectName
+                group f by m.TargetId into g
+                select new { TargetId = g.Key, Count = g.Count() })
+               .ToDictionary(x => x.TargetId, x => x.Count);
+    }
+
+    // Merge several targets into the first id in the list, NON-DESTRUCTIVELY: record each absorbed
+    // -> survivor mapping (TargetMerge). The fold is applied at query time; Undo (UndoMerge) removes
+    // the records and the absorbed targets reappear intact. No-op for < 2 distinct ids. An id already
+    // absorbed by an earlier merge is skipped so the read-time remap stays single-valued.
+    //
+    // A merge NEVER mutates a Target row — not even the survivor's name (the survivor already carries
+    // the canonical name, since the UI picks the most-integrated row as survivor; canonicalName is
+    // the panel's display snapshot). That keeps Undo a perfect inverse and means the goal-loss bug class
+    // (per-scope goals lost on merge) cannot occur: nothing is deleted or renamed, so goal collisions
+    // between the merged targets resolve via the goals dict's GroupBy+Max at read time.
+    public void MergeTargets(IReadOnlyList<int> targetIds, string canonicalName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalName);
+
+        var ids = targetIds.Distinct().ToList();
+        if (ids.Count < 2)
+            return;
+
+        using var db = _dbContextFactory.CreateDbContext();
+
+        var survivorId = ids[0];
+
+        // The ids come from rendered rows; the survivor could have been deleted (e.g. a concurrent
+        // rescan) between render and merge. Treat a vanished survivor as a no-op.
+        if (db.Targets.Find(survivorId) is null)
+            return;
+
+        var alreadyAbsorbed = db.TargetMerges.Select(m => m.AbsorbedTargetId).ToHashSet();
+        var labels = db.Targets
+            .Where(t => ids.Contains(t.Id))
+            .Select(t => new { t.Id, t.CanonicalName })
+            .AsEnumerable()
+            .ToDictionary(t => t.Id, t => t.CanonicalName);
+
+        var operationId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var newRecords = ids.Where(id => id != survivorId && !alreadyAbsorbed.Contains(id))
+            .Select(absorbedId => new TargetMerge
+            {
+                OperationId = operationId,
+                SurvivorTargetId = survivorId,
+                AbsorbedTargetId = absorbedId,
+                SurvivorLabel = canonicalName,
+                AbsorbedLabel = labels.GetValueOrDefault(absorbedId, $"Target {absorbedId}"),
+                CreatedUtc = now,
+            })
+            .ToList();
+        if (newRecords.Count == 0)
+            return;
+
+        db.TargetMerges.AddRange(newRecords);
+        db.SaveChanges();
+    }
+
+    // Fold several telescope-name spellings into one canonical scope, NON-DESTRUCTIVELY: record each
+    // absorbed -> canonical mapping (ScopeMerge). Applied at query time; Undo removes the records. A
+    // blank name, the canonical itself, an in-call duplicate, or a name already absorbed by an
+    // earlier merge is skipped so the read-time remap stays single-valued.
+    public void MergeScopes(string canonicalName, IReadOnlyList<string> absorbedNames)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalName);
+        var canonical = canonicalName.Trim();   // store the canonical trimmed, like the absorbed names
+
+        using var db = _dbContextFactory.CreateDbContext();
+
+        var alreadyAbsorbed = db.ScopeMerges.Select(m => m.AbsorbedName)
+            .AsEnumerable()
+            .Select(n => n.ToLowerInvariant())
+            .ToHashSet();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { canonical };
+
+        var operationId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var newRecords = new List<ScopeMerge>();
+        foreach (var name in absorbedNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+            var trimmed = name.Trim();
+            if (!seen.Add(trimmed))                       // canonical itself or a repeat in this call
+                continue;
+            if (alreadyAbsorbed.Contains(trimmed.ToLowerInvariant()))
+                continue;                                  // already folded by an earlier merge
+            newRecords.Add(new ScopeMerge
+            {
+                OperationId = operationId,
+                CanonicalName = canonical,
+                AbsorbedName = trimmed,
+                CreatedUtc = now,
+            });
+        }
+        if (newRecords.Count == 0)
+            return;
+
+        db.ScopeMerges.AddRange(newRecords);
+        db.SaveChanges();
+    }
+
+    // Reverse one merge action (scope or target) by removing every record that shares its
+    // OperationId. The absorbed scopes/targets reappear on the next query — nothing to restore,
+    // since the merge never deleted anything.
+    public void UndoMerge(Guid operationId)
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+        db.ScopeMerges.RemoveRange(db.ScopeMerges.Where(m => m.OperationId == operationId));
+        db.TargetMerges.RemoveRange(db.TargetMerges.Where(m => m.OperationId == operationId));
+        db.SaveChanges();
+    }
+
+    // Every active user merge, newest first, for the Manage-merges panel. Scope and target merges
+    // unify into one MergeOperation list, each grouped by OperationId (a 3-way merge is one
+    // operation carrying two absorbed labels).
+    public IReadOnlyList<MergeOperation> GetMergeOperations()
+    {
+        using var db = _dbContextFactory.CreateDbContext();
+
+        // The survivor's live name: auto-consolidation can rename a target after a merge, so the
+        // panel reads the current CanonicalName (falling back to the snapshot label if the survivor
+        // is gone) — otherwise the snapshot would show a name that no longer matches the folded row.
+        // All rows in one OperationId share their survivor, so First() picks the operation's label.
+        var targetNames = db.Targets.AsNoTracking()
+            .Select(t => new { t.Id, t.CanonicalName })
+            .AsEnumerable()
+            .ToDictionary(t => t.Id, t => t.CanonicalName);
+
+        var scopeOps = db.ScopeMerges.AsNoTracking().ToList()
+            .GroupBy(m => m.OperationId)
+            .Select(g => new MergeOperation(g.Key, MergeKind.Scope,
+                g.First().CanonicalName,   // scope names are FITS strings, never renamed — snapshot is live
+                g.Select(m => m.AbsorbedName).ToList(),
+                g.Max(m => m.CreatedUtc)));
+
+        var targetOps = db.TargetMerges.AsNoTracking().ToList()
+            .GroupBy(m => m.OperationId)
+            .Select(g => new MergeOperation(g.Key, MergeKind.Target,
+                targetNames.TryGetValue(g.First().SurvivorTargetId, out var live) ? live : g.First().SurvivorLabel,
+                g.Select(m => m.AbsorbedLabel).ToList(),
+                g.Max(m => m.CreatedUtc)));
+
+        return scopeOps.Concat(targetOps).OrderByDescending(o => o.CreatedUtc).ToList();
+    }
+
+    // Fold the absorbed targets into the survivor: repoint their name maps and per-filter
+    // goals onto it, then delete them — staged on the context so the caller's single
+    // SaveChanges commits the repoint and the delete atomically. EF's Immediate cascade-timing
+    // evaluates the cascade against the tracked FK (already the survivor), so nothing is
+    // cascade-dropped. Used ONLY by ConsolidateFormattingVariants now — the auto-fold of
+    // NormalizeKey-identical spellings, which stays destructive (reversing an auto-fold is pointless,
+    // it would re-fold next reload). User merges went non-destructive (MergeTargets / MergeScopes
+    // record-and-resolve), so this goal-protecting repoint-before-delete guards only the auto path.
+    //
+    // Goals need more than a blind repoint. TargetFilterGoal's Scope/Filter columns are BINARY
+    // but their sources (TelescopeName / FilterName) are NOCASE, so "T20"/"t20" (or "Ha"/"ha")
+    // are one physical scope+filter yet two distinct (TargetId, Scope, Filter) unique-index
+    // keys. We collapse each (scope, filter) case-insensitively and keep exactly ONE row on the
+    // survivor — the larger goal wins; every other row in the group is removed in this same
+    // SaveChanges. Repointing two rows onto one key, or leaving two case-variant rows, would
+    // either abort the merge on the unique index or strand a duplicate goal.
+    private static void AbsorbInto(LumidexDbContext db, int survivorId, IReadOnlyList<int> absorbedIds)
+    {
+        if (absorbedIds.Count == 0)
+            return;
+
+        // Name maps carry no unique constraint on the scope side, so a plain repoint is safe.
+        foreach (var map in db.TargetNameMaps.Where(m => absorbedIds.Contains(m.TargetId)))
+            map.TargetId = survivorId;
+
+        // Per-(scope, filter) goals: collision-aware merge over the survivor's + absorbed rows.
+        // Fold scope+filter with ToLowerInvariant — the SAME keys TargetGoalQuery's lookup uses,
+        // so the merge and the read agree on what "the same (scope, filter)" is.
+        var allIds = absorbedIds.Append(survivorId).ToList();
+        var goals = db.TargetFilterGoals.Where(g => allIds.Contains(g.TargetId)).ToList();
+        foreach (var key in goals.GroupBy(g => (g.Scope.ToLowerInvariant(), g.Filter.ToLowerInvariant())))
+        {
+            var winningGoal = key.Max(g => g.GoalHours);
+            // Prefer the survivor's own row as the keeper (no repoint needed); otherwise repoint
+            // exactly one absorbed row. Either way only ONE row ends up on the survivor for this
+            // (scope, filter), so the unique index never sees a duplicate.
+            var keeper = key.FirstOrDefault(g => g.TargetId == survivorId) ?? key.First();
+            keeper.TargetId = survivorId;
+            keeper.GoalHours = winningGoal;
+            foreach (var loser in key.Where(g => !ReferenceEquals(g, keeper)))
+                db.TargetFilterGoals.Remove(loser);
+        }
+
+        // A user TargetMerge points at target ids. If this auto-fold deletes a target a user merge
+        // kept as its SURVIVOR, that merge would silently un-merge (the dangling survivor is skipped
+        // at read time) and leave a ghost row in the Manage-merges panel. Repoint those records onto
+        // the new survivor so the user's merge follows the consolidation; drop any that would now
+        // self-reference (absorbed == survivor). AbsorbedTargetId is untouched, so the unique index
+        // on it is never violated. Staged on the same context -> committed in the caller's SaveChanges.
+        foreach (var m in db.TargetMerges.Where(m => absorbedIds.Contains(m.SurvivorTargetId)).ToList())
+        {
+            if (m.AbsorbedTargetId == survivorId)
+                db.TargetMerges.Remove(m);
+            else
+                m.SurvivorTargetId = survivorId;
+        }
+
+        db.Targets.RemoveRange(db.Targets.Where(t => absorbedIds.Contains(t.Id)));
+    }
+}

--- a/Lumidex.Tests/FilterCanonicalizerTests.cs
+++ b/Lumidex.Tests/FilterCanonicalizerTests.cs
@@ -1,0 +1,102 @@
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Tests;
+
+// Unit tests for the two-system filter canonicalizer: synonym folding, the bare
+// B/R imaging-vs-photometric disambiguation, and pass-through of unknowns. No DB
+// needed — the rule is pure given a filter name and its dataset context.
+public class FilterCanonicalizerTests
+{
+    // A conventional imaging rig (letters, no photometric markers): the
+    // disambiguation context for the folding cases below.
+    private static readonly string[] Imaging = { "L", "R", "G", "B", "H", "O", "S" };
+
+    [Theory]
+    [InlineData("H", "Ha")]
+    [InlineData("Ha", "Ha")]
+    [InlineData("ha", "Ha")]            // case-insensitive
+    [InlineData("Halpha", "Ha")]
+    [InlineData("Luminance", "L")]
+    [InlineData("Lum", "L")]
+    [InlineData("L", "L")]
+    [InlineData("O", "OIII")]
+    [InlineData("OIII", "OIII")]
+    [InlineData("S", "SII")]
+    [InlineData("G", "Green")]
+    [InlineData("Green", "Green")]
+    public void FoldsUnambiguousSynonyms(string raw, string expected)
+        => FilterCanonicalizer.Canonicalize(raw, Imaging).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Hb", "Hb")]
+    [InlineData("He", "He")]
+    [InlineData("N", "NII")]
+    [InlineData("NII", "NII")]
+    [InlineData("Color", "Color")]
+    [InlineData("LPro", "LPro")]
+    [InlineData("LUltimate", "LUltimate")]
+    [InlineData("L-eNhance", "L-eNhance")]
+    public void CoversLessCommonAndMultibandFilters(string raw, string expected)
+        => FilterCanonicalizer.Canonicalize(raw, Imaging).Should().Be(expected);
+
+    // Pure imaging rig (letters only): bare B/R are LRGB bands.
+    [Fact]
+    public void BareLetters_InImagingSet_AreImagingBands()
+    {
+        FilterCanonicalizer.Canonicalize("B", Imaging).Should().Be("Blue");
+        FilterCanonicalizer.Canonicalize("R", Imaging).Should().Be("Red");
+    }
+
+    // Pure photometry rig (UBVRI): the U/V/I markers make B and R photometric.
+    [Fact]
+    public void BareLetters_WithPhotometricMarkers_ArePhotometric()
+    {
+        var phot = new[] { "U", "B", "V", "R", "I" };
+        FilterCanonicalizer.Canonicalize("B", phot).Should().Be("B");
+        FilterCanonicalizer.Canonicalize("R", phot).Should().Be("R");
+        FilterCanonicalizer.Canonicalize("V", phot).Should().Be("V");
+    }
+
+    // Mixed rig (LRGB words AND photometric letters): the word form alongside the
+    // letter forces the letter to the photometric system, so "Blue"/"B" and
+    // "Red"/"R" stay DISTINCT.
+    [Fact]
+    public void BareLetters_AlongsideImagingWord_StayDistinctFromIt()
+    {
+        var mixed = new[] { "Luminance", "Red", "Green", "Blue", "Ha", "OIII", "SII", "B", "R", "U", "V", "I" };
+        FilterCanonicalizer.Canonicalize("B", mixed).Should().Be("B");
+        FilterCanonicalizer.Canonicalize("Blue", mixed).Should().Be("Blue");
+        FilterCanonicalizer.Canonicalize("R", mixed).Should().Be("R");
+        FilterCanonicalizer.Canonicalize("Red", mixed).Should().Be("Red");
+    }
+
+    // The word-form rule fires even without U/V/I: a set carrying both "Red" and "R"
+    // means the bare letter is the non-imaging system.
+    [Fact]
+    public void BareLetter_WithWordFormButNoUVI_IsPhotometric()
+    {
+        var set = new[] { "Red", "R", "Blue", "B" };
+        FilterCanonicalizer.Canonicalize("R", set).Should().Be("R");
+        FilterCanonicalizer.Canonicalize("B", set).Should().Be("B");
+    }
+
+    [Theory]
+    [InlineData("(No filter)", "(No filter)")]
+    [InlineData("", "")]
+    [InlineData("Tricolor", "Tricolor")]    // genuinely unknown — passes through, colors gray
+    public void PassesThroughEmptyAndUnknown(string raw, string expected)
+        => FilterCanonicalizer.Canonicalize(raw, Imaging).Should().Be(expected);
+
+    // The flip map covers exactly the four context-dependent labels (case-insensitively) and
+    // nothing else — goal persistence relies on every other label resolving to null here.
+    [Theory]
+    [InlineData("B", "Blue")]
+    [InlineData("blue", "B")]
+    [InlineData("r", "Red")]
+    [InlineData("RED", "R")]
+    [InlineData("L", null)]
+    [InlineData("Ha", null)]
+    [InlineData("V", null)]
+    public void FlipPartnerOf_MapsOnlyTheFourFlippableLabels(string label, string? expected)
+        => FilterCanonicalizer.FlipPartnerOf(label).Should().Be(expected);
+}

--- a/Lumidex.Tests/FilterClassifierTests.cs
+++ b/Lumidex.Tests/FilterClassifierTests.cs
@@ -1,0 +1,81 @@
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Tests;
+
+public class FilterClassifierTests
+{
+    [Theory]
+    [InlineData("L", FilterBand.Broadband)]
+    [InlineData("Red", FilterBand.Broadband)]
+    [InlineData("Ha", FilterBand.Narrowband)]
+    [InlineData("OIII", FilterBand.Narrowband)]
+    [InlineData("V", FilterBand.Photometric)]
+    [InlineData("B", FilterBand.Photometric)]
+    [InlineData("Color", FilterBand.OscMultiband)]
+    [InlineData("L-eNhance", FilterBand.OscMultiband)]
+    [InlineData("ha", FilterBand.Narrowband)]           // case-insensitive known label
+    [InlineData("color", FilterBand.OscMultiband)]      // case-insensitive known label
+    public void BandOf_KnownCanonicalLabels(string filter, FilterBand expected)
+        => FilterClassifier.BandOf(filter).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Halpha 3nm", FilterBand.Narrowband)]   // emission token in an unknown name
+    [InlineData("OIII 6.5nm", FilterBand.Narrowband)]   // token + bandwidth
+    [InlineData("5nm", FilterBand.Narrowband)]          // narrow bandwidth alone
+    [InlineData("12nm", FilterBand.Narrowband)]         // bandwidth boundary (<= 12)
+    [InlineData("13nm", FilterBand.Unknown)]            // just over the narrowband boundary
+    [InlineData("50nm", FilterBand.Unknown)]            // broadband bandwidth, not narrowband
+    [InlineData("g'", FilterBand.Photometric)]          // Sloan
+    [InlineData("i'", FilterBand.Photometric)]          // Sloan
+    [InlineData("L-Quad", FilterBand.OscMultiband)]     // OSC keyword (Quad)
+    [InlineData("Duo Ha", FilterBand.OscMultiband)]     // OSC keyword wins over the NB token (check order)
+    [InlineData("Sheet", FilterBand.Unknown)]           // "he" is mid-word → NOT narrowband (word-boundary guard)
+    [InlineData("Clear", FilterBand.Unknown)]           // genuinely unrecognised
+    public void BandOf_UnknownNames_ByPattern(string raw, FilterBand expected)
+        => FilterClassifier.BandOf(raw).Should().Be(expected);
+
+    // The full static order: bands in fixed order, then within-band — broadband L-first then
+    // RGB desc; narrowband with the SHO trio pinned first then the rest by wavelength desc;
+    // photometric asc (UBVRI); OSC curated.
+    [Fact]
+    public void SortKey_OrdersTheKnownFilters()
+    {
+        var shuffled = new[]
+        {
+            "I", "Ha", "Blue", "Color", "L", "OIII", "U", "Green", "LPro", "SII",
+            "V", "Red", "He", "B", "NII", "L-Ultimate", "Hb", "R", "L-eNhance",
+        };
+
+        var ordered = shuffled.OrderBy(FilterClassifier.SortKey).ToArray();
+
+        ordered.Should().Equal(
+            "L", "Red", "Green", "Blue",             // broadband
+            "SII", "Ha", "OIII", "NII", "Hb", "He",  // narrowband: SHO pinned, then NII/Hb/He by wavelength
+            "U", "B", "V", "R", "I",                 // photometric, wavelength asc (UBVRI)
+            "Color", "L-eNhance", "L-Ultimate", "LPro"); // OSC curated
+    }
+
+    // An unknown narrowband filter classifies into the NB band and sorts after the known NB
+    // ones (unknown wavelength → band tail) — never leaking into another band.
+    [Fact]
+    public void SortKey_UnknownNarrowband_SlotsAtNarrowbandTail()
+    {
+        var items = new[] { "Color", "Ha", "L", "Ha-band", "U" };  // Ha-band → NB by the word-boundary "Ha" token
+
+        var ordered = items.OrderBy(FilterClassifier.SortKey).ToArray();
+
+        ordered.Should().Equal("L", "Ha", "Ha-band", "U", "Color");
+    }
+
+    // The asc-band twin of the test above: an unknown PHOTOMETRIC filter (Sloan z', absent
+    // from the wavelength table) sorts to the photometric tail, after I — not to the head.
+    [Fact]
+    public void SortKey_UnknownPhotometric_SlotsAtPhotometricTail()
+    {
+        var items = new[] { "Ha", "V", "z'", "I", "Color" };
+
+        var ordered = items.OrderBy(FilterClassifier.SortKey).ToArray();
+
+        ordered.Should().Equal("Ha", "V", "I", "z'", "Color");
+    }
+}

--- a/Lumidex.Tests/Fixtures/DatabaseFixture.cs
+++ b/Lumidex.Tests/Fixtures/DatabaseFixture.cs
@@ -9,6 +9,9 @@ public class DatabaseFixture : IDisposable
 
     public string DatabaseFilename { get; }
 
+    // Exposed so tests can build their own fresh contexts against the same DB.
+    public DbContextOptions<LumidexDbContext> Options { get; }
+
     public DatabaseFixture()
     {
         var tempFilename = $"lumidex-{Path.GetFileName(Path.GetTempFileName())}.db";
@@ -20,7 +23,8 @@ public class DatabaseFixture : IDisposable
             .EnableSensitiveDataLogging(false);
 
         Directory.CreateDirectory(Path.GetDirectoryName(DatabaseFilename)!);
-        DbContext = new LumidexDbContext(builder.Options);
+        Options = builder.Options;
+        DbContext = new LumidexDbContext(Options);
         DbContext.Database.EnsureCreated();
     }
 

--- a/Lumidex.Tests/MergeResolverTests.cs
+++ b/Lumidex.Tests/MergeResolverTests.cs
@@ -1,0 +1,80 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Tests;
+
+// Pure (no DB) tests of the absorbed -> survivor resolution the query applies in memory: basic
+// folds, transitive chains, and the bounded-loop cycle guard.
+public class MergeResolverTests
+{
+    private static ScopeMerge Scope(string absorbed, string canonical)
+        => new() { AbsorbedName = absorbed, CanonicalName = canonical, OperationId = Guid.NewGuid() };
+
+    private static TargetMerge Target(int absorbed, int survivor)
+        => new() { AbsorbedTargetId = absorbed, SurvivorTargetId = survivor, OperationId = Guid.NewGuid(),
+                   SurvivorLabel = "s", AbsorbedLabel = "a" };
+
+    [Fact]
+    public void BuildScopeMap_FoldsAbsorbedToCanonical_CaseInsensitiveKey()
+    {
+        var map = MergeResolver.BuildScopeMap(new[] { Scope("iTelescope 75", "iTelescope T75") });
+
+        map["itelescope 75"].Should().Be("iTelescope T75");   // key lowercased, value keeps case
+    }
+
+    [Fact]
+    public void BuildScopeMap_ResolvesTransitiveChain_ToTerminal()
+    {
+        // A -> B and B -> C: a frame logged as A must resolve all the way to C.
+        var map = MergeResolver.BuildScopeMap(new[] { Scope("A", "B"), Scope("B", "C") });
+
+        map["a"].Should().Be("C");
+        map["b"].Should().Be("C");
+    }
+
+    // A cyclic record set has no terminal survivor; the cyclic keys are OMITTED from the map (their
+    // rows show un-folded) instead of throwing, so a reload never bricks.
+    [Fact]
+    public void BuildScopeMap_Cycle_OmitsCyclicKeys_DoesNotThrow()
+    {
+        var merges = new[] { Scope("A", "B"), Scope("B", "A") };
+
+        var build = () => MergeResolver.BuildScopeMap(merges);
+        build.Should().NotThrow();
+        build().Should().BeEmpty();                          // both keys cyclic -> nothing folds
+    }
+
+    [Fact]
+    public void BuildScopeMap_Empty_IsEmpty()
+    {
+        MergeResolver.BuildScopeMap(Array.Empty<ScopeMerge>()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildTargetMap_FoldsAbsorbedToSurvivor()
+    {
+        var map = MergeResolver.BuildTargetMap(new[] { Target(2, 1) });
+
+        map[2].Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildTargetMap_ResolvesTransitiveChain_ToTerminal()
+    {
+        // 3 -> 2 and 2 -> 1: both resolve to the terminal survivor 1.
+        var map = MergeResolver.BuildTargetMap(new[] { Target(3, 2), Target(2, 1) });
+
+        map[3].Should().Be(1);
+        map[2].Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildTargetMap_Cycle_OmitsCyclicKeys_DoesNotThrow()
+    {
+        var merges = new[] { Target(1, 2), Target(2, 1) };
+
+        var build = () => MergeResolver.BuildTargetMap(merges);
+        build.Should().NotThrow();
+        build().Should().BeEmpty();
+    }
+}

--- a/Lumidex.Tests/MergeServiceTests.cs
+++ b/Lumidex.Tests/MergeServiceTests.cs
@@ -1,0 +1,275 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Tests;
+
+// The user-facing merge surface, now NON-DESTRUCTIVE: MergeScopes / MergeTargets record an
+// absorbed -> survivor mapping instead of deleting/repointing, and UndoMerge removes the record.
+// The visible folding is verified in TargetGoalQueryTests; here we pin the records + the
+// "nothing is destroyed" contract that makes Undo possible.
+public class MergeServiceTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public MergeServiceTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetResolutionService Service() => new(new TestDbContextFactory(_fx.DatabaseFilename));
+
+    // The whole point of going non-destructive: a target merge must NOT delete the absorbed target,
+    // repoint its maps, touch its goals, or even rename the survivor — so Undo is a perfect inverse.
+    // It only records a TargetMerge. Passing a canonical name DIFFERENT from the survivor's proves the
+    // survivor is left untouched; this FAILS on the old code (which renamed and deleted).
+    [Fact]
+    public void MergeTargets_RecordsMapping_LeavesAbsorbedGoalsAndSurvivorNameIntact()
+    {
+        int survivorId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "M 31" };
+            var absorbed = new Target { CanonicalName = "Andromeda" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = survivor });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Andromeda", Target = absorbed });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = survivor, Scope = "T20", Filter = "L", GoalHours = 10 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = absorbed, Scope = "T30", Filter = "L", GoalHours = 20 });
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id;
+        }
+
+        Service().MergeTargets(new[] { survivorId, absorbedId }, "Andromeda Galaxy");
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().HaveCount(2);                                    // absorbed NOT deleted
+        verify.Targets.Single(t => t.Id == survivorId).CanonicalName.Should().Be("M 31");      // survivor name UNTOUCHED
+        verify.Targets.Single(t => t.Id == absorbedId).CanonicalName.Should().Be("Andromeda"); // absorbed name kept
+        verify.TargetNameMaps.Single(m => m.RawObjectName == "Andromeda").TargetId.Should().Be(absorbedId); // map NOT repointed
+        verify.TargetFilterGoals.Should().HaveCount(2);                          // both goals intact, untouched
+        var record = verify.TargetMerges.Should().ContainSingle().Subject;
+        record.SurvivorTargetId.Should().Be(survivorId);
+        record.AbsorbedTargetId.Should().Be(absorbedId);
+        record.AbsorbedLabel.Should().Be("Andromeda");
+    }
+
+    // F14: the canonical name is stored trimmed, like the absorbed names — no padded-canonical that
+    // would land on a different roll-up bucket than a genuine same-name scope.
+    [Fact]
+    public void MergeScopes_TrimsCanonicalName()
+    {
+        Service().MergeScopes("iTelescope T75 ", new[] { "iTelescope 75" });
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.ScopeMerges.Single().CanonicalName.Should().Be("iTelescope T75");   // trailing space trimmed
+    }
+
+    // Auto-consolidation can rename a merge survivor after the merge; the panel must show the
+    // survivor's LIVE name, not the stale snapshot, so it matches the folded row.
+    [Fact]
+    public void GetMergeOperations_TargetSurvivorRenamed_ShowsLiveName()
+    {
+        int survivorId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "Barnard 33" };
+            var absorbed = new Target { CanonicalName = "Horsehead" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id;
+        }
+
+        var svc = Service();
+        svc.MergeTargets(new[] { survivorId, absorbedId }, "Barnard 33");
+
+        // simulate auto-consolidation renaming the survivor to the new dominant spelling
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Targets.Single(t => t.Id == survivorId).CanonicalName = "B33";
+            db.SaveChanges();
+        }
+
+        var op = svc.GetMergeOperations().Single(o => o.Kind == MergeKind.Target);
+        op.SurvivorLabel.Should().Be("B33");                                  // live name, not the "Barnard 33" snapshot
+    }
+
+    // < 2 distinct ids is a no-op (a row "merged with itself" via a repeated id writes no record).
+    [Fact]
+    public void MergeTargets_FewerThanTwoDistinct_WritesNoRecord()
+    {
+        int onlyId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.SaveChanges();
+            onlyId = t.Id;
+        }
+
+        Service().MergeTargets(new[] { onlyId, onlyId }, "M 31");
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetMerges.Should().BeEmpty();
+    }
+
+    // A repeated survivor id must not produce a survivor->survivor record; Distinct() collapses it
+    // so only the real absorbed mapping is written.
+    [Fact]
+    public void MergeTargets_DuplicateSurvivorId_WritesOnlyTheAbsorbedRecord()
+    {
+        int survivorId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "M 31" };
+            var absorbed = new Target { CanonicalName = "Andromeda" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id;
+        }
+
+        Service().MergeTargets(new[] { survivorId, survivorId, absorbedId }, "Andromeda Galaxy");
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        var record = verify.TargetMerges.Should().ContainSingle().Subject;       // no survivor->survivor row
+        record.SurvivorTargetId.Should().Be(survivorId);
+        record.AbsorbedTargetId.Should().Be(absorbedId);
+    }
+
+    // An id already absorbed by an earlier merge is skipped so the read-time remap stays
+    // single-valued (one survivor per absorbed id).
+    [Fact]
+    public void MergeTargets_AlreadyAbsorbedId_IsSkipped()
+    {
+        int survivorId, absorbedId, otherId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "M 31" };
+            var absorbed = new Target { CanonicalName = "Andromeda" };
+            var other = new Target { CanonicalName = "M 32" };
+            db.Targets.AddRange(survivor, absorbed, other);
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id; otherId = other.Id;
+        }
+
+        var svc = Service();
+        svc.MergeTargets(new[] { survivorId, absorbedId }, "Andromeda Galaxy");   // absorbed -> survivor
+        svc.MergeTargets(new[] { otherId, absorbedId }, "M 32");                  // try to re-absorb 'absorbed'
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetMerges.Where(m => m.AbsorbedTargetId == absorbedId).Should().ContainSingle(); // not re-recorded
+        verify.TargetMerges.Single(m => m.AbsorbedTargetId == absorbedId).SurvivorTargetId.Should().Be(survivorId);
+    }
+
+    // A vanished survivor (deleted between render and merge) is a no-op: no record, absorbed
+    // untouched — never escapes to the global handler.
+    [Fact]
+    public void MergeTargets_VanishedSurvivor_IsNoOp()
+    {
+        int absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var absorbed = new Target { CanonicalName = "Andromeda" };
+            db.Targets.Add(absorbed);
+            db.SaveChanges();
+            absorbedId = absorbed.Id;
+        }
+
+        var merge = () => Service().MergeTargets(new[] { absorbedId + 1000, absorbedId }, "Andromeda Galaxy");
+
+        merge.Should().NotThrow();
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetMerges.Should().BeEmpty();
+        verify.Targets.Single().CanonicalName.Should().Be("Andromeda");
+    }
+
+    // Scope merge records each absorbed telescope-name -> canonical, sharing one OperationId.
+    [Fact]
+    public void MergeScopes_RecordsAbsorbedToCanonical()
+    {
+        Service().MergeScopes("iTelescope T75", new[] { "iTelescope 75 ", "iTelescope 76" });
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.ScopeMerges.Should().HaveCount(2);
+        verify.ScopeMerges.Select(m => m.AbsorbedName).Should().BeEquivalentTo(new[] { "iTelescope 75", "iTelescope 76" }); // first trimmed
+        verify.ScopeMerges.Select(m => m.CanonicalName).Should().AllBe("iTelescope T75");
+        verify.ScopeMerges.Select(m => m.OperationId).Distinct().Should().ContainSingle(); // one operation
+    }
+
+    // The canonical itself, an in-call duplicate, and a name already folded by an earlier merge are
+    // all skipped so the absorbed -> canonical remap never becomes many-valued.
+    [Fact]
+    public void MergeScopes_SkipsSelfDuplicateAndAlreadyAbsorbed()
+    {
+        var svc = Service();
+        svc.MergeScopes("T75", new[] { "T75old" });                              // first fold
+        svc.MergeScopes("T75", new[] { "T75", "T75 ", "T80", "T80", "T75old" }); // self, padded-self, dup, already-absorbed
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.ScopeMerges.Select(m => m.AbsorbedName).OrderBy(x => x)
+            .Should().BeEquivalentTo(new[] { "T75old", "T80" });                 // only the one new, valid name added
+    }
+
+    // Undo removes exactly the records of one operation (scope or target), leaving others.
+    [Fact]
+    public void UndoMerge_RemovesOnlyThatOperationsRecords()
+    {
+        int survivorId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "M 31" };
+            var absorbed = new Target { CanonicalName = "Andromeda" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id;
+        }
+
+        var svc = Service();
+        svc.MergeScopes("T75", new[] { "T75alt" });
+        svc.MergeTargets(new[] { survivorId, absorbedId }, "Andromeda Galaxy");
+
+        var ops = svc.GetMergeOperations();
+        var scopeOp = ops.Single(o => o.Kind == MergeKind.Scope);
+        svc.UndoMerge(scopeOp.OperationId);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.ScopeMerges.Should().BeEmpty();                  // the undone scope merge is gone
+        verify.TargetMerges.Should().ContainSingle();           // the target merge is untouched
+    }
+
+    // The panel feed: scope and target merges unify into one MergeOperation list, each grouped by
+    // OperationId (a 3-way merge is one operation carrying two absorbed labels).
+    [Fact]
+    public void GetMergeOperations_UnifiesScopeAndTarget_GroupsByOperation()
+    {
+        int survivorId, aId, bId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            var survivor = new Target { CanonicalName = "M 31" };
+            var a = new Target { CanonicalName = "Andromeda" };
+            var b = new Target { CanonicalName = "And." };
+            db.Targets.AddRange(survivor, a, b);
+            db.SaveChanges();
+            survivorId = survivor.Id; aId = a.Id; bId = b.Id;
+        }
+
+        var svc = Service();
+        svc.MergeScopes("T75", new[] { "T75a", "T75b" });
+        svc.MergeTargets(new[] { survivorId, aId, bId }, "M 31");   // UI passes the survivor's own name
+
+        var ops = svc.GetMergeOperations();
+        ops.Should().HaveCount(2);                                               // one scope op + one target op
+
+        var scope = ops.Single(o => o.Kind == MergeKind.Scope);
+        scope.SurvivorLabel.Should().Be("T75");
+        scope.AbsorbedLabels.Should().BeEquivalentTo(new[] { "T75a", "T75b" });
+
+        var target = ops.Single(o => o.Kind == MergeKind.Target);
+        target.SurvivorLabel.Should().Be("M 31");                                 // survivor's live name, not the stale stored label
+        target.AbsorbedLabels.Should().BeEquivalentTo(new[] { "Andromeda", "And." }); // both absorbed in one op
+    }
+}

--- a/Lumidex.Tests/TargetGoalQueryTests.cs
+++ b/Lumidex.Tests/TargetGoalQueryTests.cs
@@ -1,0 +1,575 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Tests.Fixtures;
+
+namespace Lumidex.Tests;
+
+public class TargetGoalQueryTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetGoalQueryTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetGoalQuery Query() => new(new TestDbContextFactory(_fx.DatabaseFilename));
+
+    // Dustin's worked example: goals live on filters; scope/target goals are derived sums; an
+    // unset filter's goal defaults to its current actual (so it reads as complete and adds its
+    // hours to the rolled-up goal). Bode's on Eon70 = Red 30h (goal 30) + Blue 30h (goal 30),
+    // plus T68 Color 1h with no goal -> Eon70 goal 60, T68 goal 1, Bode's goal 61.
+    [Fact]
+    public void GetTargetGoals_RollsUpFilterGoals_UnsetDefaultsToActual()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Bode's" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Bode's", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="r", Path="/r", ObjectName="Bode's", Type=ImageType.Light, TelescopeName="Eon70", FilterName="Red",   Exposure=30*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Bode's", Type=ImageType.Light, TelescopeName="Eon70", FilterName="Blue",  Exposure=30*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Bode's", Type=ImageType.Light, TelescopeName="T68",   FilterName="Color", Exposure=1*3600,  LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "Eon70", Filter = "Red",  GoalHours = 30 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "Eon70", Filter = "Blue", GoalHours = 30 });
+            db.SaveChanges();
+        }
+
+        var bodes = Query().GetTargetGoals().Single(r => r.CanonicalName == "Bode's");
+
+        bodes.Hours.Should().BeApproximately(61, 1e-6);
+        bodes.Goal.Should().BeApproximately(61, 1e-6);   // 30 + 30 + (unset Color = its 1h actual)
+
+        var eon70 = bodes.Scopes.Single(s => s.Scope == "Eon70");
+        eon70.Hours.Should().BeApproximately(60, 1e-6);
+        eon70.Goal.Should().BeApproximately(60, 1e-6);
+
+        var t68 = bodes.Scopes.Single(s => s.Scope == "T68");
+        t68.Goal.Should().BeApproximately(1, 1e-6);      // Color unset -> goal = actual
+
+        var color = t68.Filters.Single(f => f.Filter == "Color");
+        color.ExplicitGoal.Should().BeNull();
+        color.EffectiveGoal.Should().BeApproximately(1, 1e-6);
+    }
+
+    // An explicit goal above the acquired hours stays the goal (the filter reads < 100%), and
+    // it's the explicit value that rolls up — not the smaller actual.
+    [Fact]
+    public void GetTargetGoals_ExplicitGoalAboveActual_GoalIsExplicit()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 81" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 81", Target = t });
+            db.ImageFiles.Add(new ImageFile { HeaderHash="h", Path="/h", ObjectName="M 81", Type=ImageType.Light, TelescopeName="Eon70", FilterName="Ha", Exposure=10*3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "Eon70", Filter = "Ha", GoalHours = 40 });
+            db.SaveChanges();
+        }
+
+        var ha = Query().GetTargetGoals().Single().Scopes.Single().Filters.Single();
+        ha.Hours.Should().BeApproximately(10, 1e-6);
+        ha.ExplicitGoal.Should().Be(40);
+        ha.EffectiveGoal.Should().Be(40);                       // explicit wins even though actual is less
+
+        Query().GetTargetGoals().Single().Goal.Should().BeApproximately(40, 1e-6);
+    }
+
+    // Date extents span all the frames of a group (the date-sort inputs), ignoring null
+    // observation times.
+    [Fact]
+    public void GetTargetGoals_DateExtents_SpanFrames()
+    {
+        var d1 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var d2 = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="Eon70", FilterName="L", Exposure=3600, ObservationTimestampUtc=d2, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31", Type=ImageType.Light, TelescopeName="Eon70", FilterName="L", Exposure=3600, ObservationTimestampUtc=d1, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var row = Query().GetTargetGoals().Single();
+        row.First.Should().Be(d1);   // earliest frame
+        row.Last.Should().Be(d2);    // latest frame
+    }
+
+    // Filter synonyms canonicalize before the roll-up, so "H" and "Ha" merge into one filter
+    // row with their hours summed.
+    [Fact]
+    public void GetTargetGoals_CanonicalizesFilterSynonyms()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="Eon70", FilterName="H",  Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31", Type=ImageType.Light, TelescopeName="Eon70", FilterName="Ha", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single().Scopes.Single();
+        scope.Filters.Should().ContainSingle();                        // H + Ha merge to one canonical filter
+        scope.Filters.Single().Filter.Should().Be("Ha");
+        scope.Filters.Single().Hours.Should().BeApproximately(2, 1e-6); // 1h + 1h
+    }
+
+    // An active ScopeMerge folds two telescope-name spellings on a target into ONE scope row at read
+    // time, hours summed — no physical change to the frames (Undo just removes the record).
+    [Fact]
+    public void GetTargetGoals_ScopeMerge_FoldsTwoScopesIntoOneRow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Horsehead" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="iTelescope 75",  FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="iTelescope T75", FilterName="Ha", Exposure=3*3600, LibraryId=1 });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "iTelescope 75", CanonicalName = "iTelescope T75" });
+            db.SaveChanges();
+        }
+
+        var row = Query().GetTargetGoals().Single(r => r.CanonicalName == "Horsehead");
+        var scope = row.Scopes.Should().ContainSingle().Subject;       // the two spellings fold to one scope
+        scope.Scope.Should().Be("iTelescope T75");                     // ...under the canonical name
+        scope.Hours.Should().BeApproximately(5, 1e-6);                 // 2h + 3h summed
+    }
+
+    // An active TargetMerge folds two distinct-name targets into ONE row at read time; the absorbed
+    // target's frames roll up under the survivor's canonical name.
+    [Fact]
+    public void GetTargetGoals_TargetMerge_FoldsTwoTargetsIntoOneRow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var survivor = new Target { CanonicalName = "Horsehead" };
+            var absorbed = new Target { CanonicalName = "Barnard 33" };   // different words -> no auto-consolidate
+            db.Targets.AddRange(survivor, absorbed);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = survivor });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Barnard 33", Target = absorbed });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead",  Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Barnard 33", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3*3600, LibraryId=1 });
+            db.SaveChanges();
+            db.TargetMerges.Add(new TargetMerge { OperationId = Guid.NewGuid(), SurvivorTargetId = survivor.Id, AbsorbedTargetId = absorbed.Id, SurvivorLabel = "Horsehead", AbsorbedLabel = "Barnard 33" });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetGoals().Where(r => r.TargetId != 0).ToList();
+        var row = rows.Should().ContainSingle().Subject;               // two targets fold to one row
+        row.CanonicalName.Should().Be("Horsehead");                    // ...under the survivor's name
+        row.Hours.Should().BeApproximately(5, 1e-6);                   // both targets' frames summed
+    }
+
+    // When both merged targets set a goal for the same scope+filter, the rolled-up goal is the
+    // larger (the goals dict's GroupBy+Max) — no physical goal merge needed.
+    [Fact]
+    public void GetTargetGoals_TargetMerge_GoalCollision_PicksMax()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var survivor = new Target { CanonicalName = "Horsehead" };
+            var absorbed = new Target { CanonicalName = "Barnard 33" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = survivor });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Barnard 33", Target = absorbed });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead",  Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Barnard 33", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3*3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = survivor, Scope = "T20", Filter = "Ha", GoalHours = 10 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = absorbed, Scope = "T20", Filter = "Ha", GoalHours = 25 });
+            db.SaveChanges();
+            db.TargetMerges.Add(new TargetMerge { OperationId = Guid.NewGuid(), SurvivorTargetId = survivor.Id, AbsorbedTargetId = absorbed.Id, SurvivorLabel = "Horsehead", AbsorbedLabel = "Barnard 33" });
+            db.SaveChanges();
+        }
+
+        var filter = Query().GetTargetGoals().Single(r => r.TargetId != 0).Scopes.Single().Filters.Single();
+        filter.Hours.Should().BeApproximately(5, 1e-6);                // both targets' Ha summed
+        filter.ExplicitGoal.Should().Be(25);                          // the larger of the two colliding goals
+    }
+
+    // A TargetMerge whose survivor id no longer exists (auto-consolidation deleted it) is skipped,
+    // not crashed — the absorbed target stands on its own.
+    [Fact]
+    public void GetTargetGoals_TargetMerge_DanglingSurvivor_IsSkipped()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Horsehead" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = t });
+            db.ImageFiles.Add(new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=2*3600, LibraryId=1 });
+            db.SaveChanges();
+            db.TargetMerges.Add(new TargetMerge { OperationId = Guid.NewGuid(), SurvivorTargetId = t.Id + 9999, AbsorbedTargetId = t.Id, SurvivorLabel = "gone", AbsorbedLabel = "Horsehead" });
+            db.SaveChanges();
+        }
+
+        var query = Query();
+        var act = () => query.GetTargetGoals();
+        act.Should().NotThrow();                                       // dangling survivor must not crash
+        act().Single(r => r.TargetId != 0).CanonicalName.Should().Be("Horsehead"); // absorbed stands alone
+    }
+
+    // F5: undo's user-visible effect — a merge folds two targets to one row; undo restores two rows.
+    // The record-deletion is unit-tested elsewhere; this pins the headline promise through the query.
+    [Fact]
+    public void GetTargetGoals_UndoTargetMerge_RestoresSeparateRows()
+    {
+        int survivorId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var survivor = new Target { CanonicalName = "Horsehead" };
+            var absorbed = new Target { CanonicalName = "Barnard 33" };
+            db.Targets.AddRange(survivor, absorbed);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = survivor });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Barnard 33", Target = absorbed });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead",  Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Barnard 33", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3*3600, LibraryId=1 });
+            db.SaveChanges();
+            survivorId = survivor.Id; absorbedId = absorbed.Id;
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.MergeTargets(new[] { survivorId, absorbedId }, "Horsehead");
+        Query().GetTargetGoals().Count(r => r.TargetId != 0).Should().Be(1);   // folded to one row
+
+        svc.UndoMerge(svc.GetMergeOperations().Single().OperationId);
+
+        var rows = Query().GetTargetGoals().Where(r => r.TargetId != 0).ToList();
+        rows.Should().HaveCount(2);                                            // re-separated by undo
+        rows.Select(r => r.CanonicalName).Should().BeEquivalentTo(new[] { "Horsehead", "Barnard 33" });
+    }
+
+    // F6: a goal stored under an ABSORBED scope name must roll up under the CANONICAL scope row after
+    // a scope merge — the goals-dict scope remap. (Its target-side twin is tested above; this side
+    // had no coverage, so deleting the remap would otherwise leave every test green.)
+    [Fact]
+    public void GetTargetGoals_ScopeMerge_GoalUnderAbsorbedScope_RollsUpUnderCanonical()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Horsehead" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="iTelescope 75",  FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="iTelescope T75", FilterName="Ha", Exposure=3*3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "iTelescope 75", Filter = "Ha", GoalHours = 30 }); // under the absorbed spelling
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "iTelescope 75", CanonicalName = "iTelescope T75" });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "Horsehead").Scopes.Single();
+        scope.Scope.Should().Be("iTelescope T75");
+        scope.Filters.Single(f => f.Filter == "Ha").ExplicitGoal.Should().Be(30);   // goal followed the fold
+    }
+
+    // F11b: a transitive scope chain (A->B then B->C, formed by re-merging a survivor) folds all the
+    // way to C through the REAL query, not just the resolver unit — three spellings, one scope row.
+    [Fact]
+    public void GetTargetGoals_TransitiveScopeChain_FoldsToTerminal()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Horsehead" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="A", FilterName="Ha", Exposure=1*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="B", FilterName="Ha", Exposure=2*3600, LibraryId=1 },
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="C", FilterName="Ha", Exposure=4*3600, LibraryId=1 });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "A", CanonicalName = "B" });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "B", CanonicalName = "C" });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "Horsehead").Scopes.Should().ContainSingle().Subject;
+        scope.Scope.Should().Be("C");                                  // A and B both chain to C
+        scope.Hours.Should().BeApproximately(7, 1e-6);                 // 1 + 2 + 4
+    }
+
+    // Resolver totality: a cyclic merge record set (the UI can't create one, but a corrupt DB or
+    // an odd consolidation sequence could) must NOT brick the query — the cyclic keys omit from the
+    // map, so the scopes render UN-FOLDED rather than throwing out of the reload.
+    [Fact]
+    public void GetTargetGoals_CyclicScopeMerges_RenderUnfolded_DoesNotThrow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "Horsehead" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Horsehead", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="A", FilterName="Ha", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Horsehead", Type=ImageType.Light, TelescopeName="B", FilterName="Ha", Exposure=3600, LibraryId=1 });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "A", CanonicalName = "B" });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "B", CanonicalName = "A" });
+            db.SaveChanges();
+        }
+
+        var query = Query();
+        var act = () => query.GetTargetGoals();
+        act.Should().NotThrow();                                                          // cyclic set must not brick the tab
+        act().Single(r => r.CanonicalName == "Horsehead").Scopes.Should().HaveCount(2);   // both scopes un-folded
+    }
+
+    // A goal saved while a scope's bare B rendered as imaging "Blue" must still attach after
+    // photometric evidence (here a V frame) flips the cell's canonical label to "B" — the
+    // stored label no longer matches, so the query's flip-partner fallback carries it over.
+    // Without the fallback the goal silently vanishes from the UI.
+    [Fact]
+    public void GetTargetGoals_GoalSavedBeforePhotometricFlip_StillAttaches()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="b1", Path="/b1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="B", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="v1", Path="/v1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="V", Exposure=1800, LibraryId=1 });
+            // Saved before the V run landed, when the scope's set was imaging-only and the
+            // bare B canonicalized to "Blue".
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "Blue", GoalHours = 10 });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31").Scopes.Single();
+
+        var b = scope.Filters.Single(f => f.Filter == "B");   // V present -> bare B is photometric
+        b.ExplicitGoal.Should().Be(10);                        // the pre-flip "Blue" goal still attaches
+        scope.Goal.Should().BeApproximately(10.5, 1e-6);       // and rolls up: 10 + V's unset 0.5h actual
+    }
+
+    // ADV-1 scenario B: the flip induced by a scope MERGE. The goal's scope key remaps to the
+    // survivor AND the merged filter set flips the bare letter — the two mechanisms compose.
+    [Fact]
+    public void GetTargetGoals_ScopeMergeInducedFlip_GoalStillAttaches()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="m1", Path="/m1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30",  FilterName="B", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="m2", Path="/m2", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30b", FilterName="V", Exposure=1800, LibraryId=1 });
+            // Goal saved pre-merge, when T30's set was imaging-only and its bare B rendered "Blue".
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "Blue", GoalHours = 10 });
+            // Merging the photometric rig's scope in flips T30's bare B to "B".
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "T30b", CanonicalName = "T30" });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31").Scopes.Single();
+
+        scope.Scope.Should().Be("T30");                        // merged into the survivor
+        scope.Filters.Single(f => f.Filter == "B")             // V present post-merge -> photometric
+            .ExplicitGoal.Should().Be(10);                     // the pre-merge "Blue" goal still attaches
+    }
+
+    // The live query sums Light frames only — a calibration frame's exposure must not inflate
+    // the target's hours.
+    [Fact]
+    public void GetTargetGoals_ExcludesNonLightFrames()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="l1", Path="/l1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="d1", Path="/d1", ObjectName="M 31", Type=ImageType.Dark,  TelescopeName="T20", FilterName="L", Exposure=9999, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var m31 = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31");
+        m31.Hours.Should().BeApproximately(1.0, 1e-6);   // the dark's 9999s is excluded
+    }
+
+    // The flip fallback must NOT borrow a goal that belongs to a coexisting partner cell: a
+    // scope carrying a photometric bare "B" AND the imaging word "Blue" renders both cells,
+    // and a goal stored under "Blue" belongs to the "Blue" cell only. Borrowing it for "B"
+    // would display and roll up the same goal twice.
+    [Fact]
+    public void GetTargetGoals_FlipPartnerGoal_NotBorrowedWhenPartnerCellExists()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="p1", Path="/p1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="B",    Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="p2", Path="/p2", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="Blue", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="p3", Path="/p3", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="V",    Exposure=1800, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "Blue", GoalHours = 10 });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31").Scopes.Single();
+
+        scope.Filters.Single(f => f.Filter == "Blue").ExplicitGoal.Should().Be(10);   // stays on its own cell
+        scope.Filters.Single(f => f.Filter == "B").ExplicitGoal.Should().BeNull();    // not borrowed
+    }
+
+    // The reverse flip: a goal saved while the scope was photometric (stored as "B") must still
+    // attach after the photometric evidence goes away (frames culled / merge undone) and the
+    // bare letter renders as imaging "Blue" again.
+    [Fact]
+    public void GetTargetGoals_GoalSavedAsPhotometricLetter_AttachesAfterFlipBack()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="i1", Path="/i1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="B", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="i2", Path="/i2", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="L", Exposure=1800, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "B", GoalHours = 8 });
+            db.SaveChanges();
+        }
+
+        var scope = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31").Scopes.Single();
+
+        var blue = scope.Filters.Single(f => f.Filter == "Blue");   // no U/V/I, no word form -> imaging
+        blue.ExplicitGoal.Should().Be(8);                            // the photometric-era "B" goal still attaches
+    }
+
+    // ---- Bucket-path coverage:
+    // the three bucket paths below are where hours can silently under-count, so each boundary
+    // is pinned explicitly.
+
+    // A Light frame with a null ObjectName lands in the synthetic "(Unnamed)" pile.
+    [Fact]
+    public void GetTargetGoals_BucketsNullObjectName_AsUnnamed()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.Add(
+                new ImageFile { HeaderHash="x", Path="/x", ObjectName=null, Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetGoals();
+        rows.Should().ContainSingle(r => r.CanonicalName == "(Unnamed)" && Math.Abs(r.Hours - 1.0) < 1e-6);
+        rows.Single().TargetId.Should().Be(0);   // synthetic id — merge/goal-edit exclude it
+    }
+
+    // A non-empty ObjectName with no TargetNameMap must NOT be silently dropped by the inner
+    // join: it surfaces under its own name as a synthetic row so its hours still count.
+    [Fact]
+    public void GetTargetGoals_BucketsNamedButUnmapped_UnderOwnName()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            // No TargetNameMap for "NGC 7000": an inner-join-only query would drop this frame.
+            db.ImageFiles.Add(
+                new ImageFile { HeaderHash="u1", Path="/u1", ObjectName="NGC 7000", Type=ImageType.Light, TelescopeName="T20", FilterName="Ha", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetGoals();
+        rows.Should().ContainSingle(r => r.CanonicalName == "NGC 7000" && Math.Abs(r.Hours - 1.0) < 1e-6);
+    }
+
+    // Whitespace-only ObjectNames belong in "(Unnamed)", not the named-but-unmapped bucket.
+    // The tab variant proves the classification runs client-side — SQLite's TRIM strips only
+    // spaces, so the SQL predicate alone can't catch it.
+    [Fact]
+    public void GetTargetGoals_BucketsWhitespaceObjectName_AsUnnamed()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="w1", Path="/w1", ObjectName="   ", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="w2", Path="/w2", ObjectName="\t",  Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=1800, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetGoals();
+        rows.Should().ContainSingle();
+        rows.Single().CanonicalName.Should().Be("(Unnamed)");
+        rows.Single().Hours.Should().BeApproximately(1.5, 1e-6);   // both whitespace frames fold together
+    }
+
+    // FITS space-padding ("M 31" vs "M 31 ") must not split a target's hours across two rows:
+    // both frames trim to the same name, join the single map, and sum into ONE row.
+    [Fact]
+    public void GetTargetGoals_WhitespacePaddedObjectNames_FoldIntoOneRow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="f1", Path="/f1", ObjectName="M 31",  Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="f2", Path="/f2", ObjectName="M 31 ", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=1800, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var rows = Query().GetTargetGoals();
+        rows.Should().ContainSingle();                             // no split row for the padded twin
+        rows.Single().CanonicalName.Should().Be("M 31");
+        rows.Single().Hours.Should().BeApproximately(1.5, 1e-6);   // both frames sum into the one mapped target
+    }
+
+    // A Light frame with null TelescopeName and null FilterName must bucket under the
+    // "(Unknown scope)" / "(No filter)" defaults, not vanish or null-key a group.
+    [Fact]
+    public void GetTargetGoals_NullScopeAndFilter_UseDefaultBuckets()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.Add(
+                new ImageFile { HeaderHash="n1", Path="/n1", ObjectName="M 31", Type=ImageType.Light, TelescopeName=null, FilterName=null, Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var m31 = Query().GetTargetGoals().Single(r => r.CanonicalName == "M 31");
+        var scope = m31.Scopes.Should().ContainSingle().Which;
+        scope.Scope.Should().Be("(Unknown scope)");
+        scope.Filters.Should().ContainSingle(f => f.Filter == "(No filter)");
+    }
+}

--- a/Lumidex.Tests/TargetResolutionServiceTests.cs
+++ b/Lumidex.Tests/TargetResolutionServiceTests.cs
@@ -1,0 +1,362 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Tests;
+
+// Each test needs an isolated DB. The shared DatabaseFixture file is reused, but
+// the ctor wipes and recreates the schema so seeded rows from one test never leak
+// into the next. (The fixture itself is created once per class by IClassFixture.)
+//
+// Covers name resolution + auto-consolidation (the destructive AbsorbInto path that stays for
+// formatting-variant folds). The user-facing merge surface (now non-destructive records + undo)
+// lives in MergeServiceTests; read-time folding lives in TargetGoalQueryTests.
+public class TargetResolutionServiceTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetResolutionServiceTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    [Fact]
+    public void Target_And_NameMap_Persist_And_Relate()
+    {
+        using var db = new LumidexDbContext(_fx.Options);
+        var target = new Target { CanonicalName = "Andromeda Galaxy" };
+        db.Targets.Add(target);
+        db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = target });
+        db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Andromeda", Target = target });
+        db.SaveChanges();
+
+        var loaded = db.Targets.Include(t => t.NameMaps).Single();
+        loaded.NameMaps.Should().HaveCount(2);
+        loaded.CanonicalName.Should().Be("Andromeda Galaxy");
+    }
+
+    [Fact]
+    public void EnsureTargetsResolved_CreatesOneTargetPerDistinctName_AndIsIdempotent()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            // ImageFile.LibraryId is a required FK; seed the Library row it points at.
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "a", Path = "/a", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "b", Path = "/b", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "c", Path = "/c", ObjectName = "M 104", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "d", Path = "/d", ObjectName = null,    Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+        svc.EnsureTargetsResolved(); // idempotent
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).OrderBy(x => x)
+            .Should().BeEquivalentTo(new[] { "M 104", "M 31" });   // null ObjectName produces no map
+        verify.TargetNameMaps.Should().HaveCount(2);
+    }
+
+    // A whitespace-only ObjectName ("   ", "\t") must be treated as empty: it spawns
+    // no Target and no map (the merge side already rejects whitespace via
+    // ThrowIfNullOrWhiteSpace — resolution must be symmetric). SQLite's TRIM only
+    // strips spaces, so the tab case proves the filter runs client-side.
+    [Fact]
+    public void EnsureTargetsResolved_WhitespaceObjectName_CreatesNoTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "sp", Path = "/sp", ObjectName = "   ", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "tab", Path = "/tab", ObjectName = "\t", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "real", Path = "/real", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).Should().BeEquivalentTo(new[] { "M 31" }); // whitespace produces no junk target
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+
+    // Case-variant ObjectNames ("M 31" / "m 31") must collapse to ONE Target — the
+    // NOCASE promise. Two layers enforce it: ImageFile.ObjectName is TEXT COLLATE
+    // NOCASE so the DISTINCT scan already folds the variants, and the OrdinalIgnoreCase
+    // HashSet folds again as a backstop. This asserts the observable contract (one
+    // target, one map) rather than the mechanism, so it holds if either layer changes.
+    [Fact]
+    public void EnsureTargetsResolved_CaseVariantObjectNames_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "u", Path = "/u", ObjectName = "M 31", Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "l", Path = "/l", ObjectName = "m 31", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();          // case variants do not spawn two targets
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+
+    // FITS headers often space-pad OBJECT, so "M 31" and "M 31 " arrive as distinct
+    // strings and would mint two Targets, splitting integration across two rows. Both
+    // must trim to the same identity and collapse to ONE Target + ONE map.
+    [Fact]
+    public void EnsureTargetsResolved_WhitespacePaddedObjectNames_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash = "p", Path = "/p", ObjectName = "M 31",  Type = ImageType.Light, LibraryId = 1 },
+                new ImageFile { HeaderHash = "t", Path = "/t", ObjectName = "M 31 ", Type = ImageType.Light, LibraryId = 1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();          // trailing-space twin does not spawn a second target
+        verify.TargetNameMaps.Should().ContainSingle();
+    }
+
+    // ConsolidateFormattingVariants runs automatically inside EnsureTargetsResolved on
+    // every tab load — so a per-scope goal on an absorbed variant is the data-loss path
+    // that fires with NO user action. The goal on the absorbed spelling must follow to the
+    // survivor.
+    [Fact]
+    public void EnsureTargetsResolved_Consolidation_PreservesPerFilterGoals()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var big = new Target { CanonicalName = "M101" };           // dominant spelling -> survivor
+            var small = new Target { CanonicalName = "M 101" };
+            db.Targets.AddRange(big, small);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = big });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = small });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M 101", Type=ImageType.Light, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = small, Scope = "T20", Filter = "L", GoalHours = 15 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();                           // the two variants consolidated
+        var goal = verify.TargetFilterGoals.Should().ContainSingle().Subject;
+        goal.GoalHours.Should().Be(15);                                    // absorbed variant's goal survived
+        goal.TargetId.Should().Be(verify.Targets.Single().Id);            // ...repointed onto the survivor
+    }
+
+    // AbsorbInto's collision de-dupe still runs on the consolidation path (its only remaining
+    // caller). Two formatting-variant targets each set a goal for the same physical scope spelled
+    // in different case ("T20"/"t20") — TargetFilterGoal.Scope is BINARY but its source is NOCASE,
+    // so they are one logical scope but two unique-index keys. Consolidation must collapse them to
+    // one row (larger goal wins) without aborting on the unique index.
+    [Fact]
+    public void EnsureTargetsResolved_Consolidation_CollidingCaseVariantGoals_KeepsLarger()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var big = new Target { CanonicalName = "M101" };           // dominant -> survivor
+            var small = new Target { CanonicalName = "M 101" };
+            db.Targets.AddRange(big, small);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = big });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = small });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M 101", Type=ImageType.Light, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = big,   Scope = "T20", Filter = "L", GoalHours = 10 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = small, Scope = "t20", Filter = "L", GoalHours = 40 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        var resolve = () => svc.EnsureTargetsResolved();
+
+        resolve.Should().NotThrow();                                        // no unique-index abort mid-consolidate
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetFilterGoals.Should().ContainSingle();                  // the case-variants collapse to one row
+        verify.TargetFilterGoals.Single().GoalHours.Should().Be(40);        // larger goal wins
+    }
+
+    // Two absorbed variants share a scope goal and the survivor has none — exercises AbsorbInto's
+    // "keeper = group.First()" branch (no survivor row to prefer). Three same-key spellings fold to
+    // one target; the two colliding goals collapse to one, larger wins.
+    [Fact]
+    public void EnsureTargetsResolved_Consolidation_TwoAbsorbedShareScope_KeepsLarger()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var big = new Target { CanonicalName = "M101" };          // dominant -> survivor, no goal
+            var a = new Target { CanonicalName = "M 101" };
+            var b = new Target { CanonicalName = "M-101" };           // hyphen folds to the same key
+            db.Targets.AddRange(big, a, b);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = big });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = a });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M-101", Target = b });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M 101", Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="4", Path="/4", ObjectName="M-101", Type=ImageType.Light, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = a, Scope = "T20", Filter = "L", GoalHours = 8 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = b, Scope = "T20", Filter = "L", GoalHours = 22 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        var resolve = () => svc.EnsureTargetsResolved();
+
+        resolve.Should().NotThrow();                                        // both absorbed goals fold to one, no abort
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();
+        verify.TargetFilterGoals.Should().ContainSingle();
+        verify.TargetFilterGoals.Single().GoalHours.Should().Be(22);        // larger of the two absorbed goals
+    }
+
+    // Light dedupe: formatting variants of a name in the raw data (whitespace /
+    // punctuation / case) map to ONE target each, not several.
+    [Fact]
+    public void EnsureTargetsResolved_FormattingVariants_CollapseToOneTarget()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="NGC 2070",      Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="Ngc2070",       Type=ImageType.Light, LibraryId=1 }, // whitespace+case twin
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Bode's Galaxy", Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="d", Path="/d", ObjectName="Bodes Galaxy",  Type=ImageType.Light, LibraryId=1 }); // apostrophe twin
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().HaveCount(2);                          // NGC 2070 family + Bode's family
+        verify.TargetNameMaps.Should().HaveCount(4);                  // every raw spelling still maps
+        verify.TargetNameMaps.Select(m => m.TargetId).Distinct().Should().HaveCount(2);
+    }
+
+    // Existing fragmentation (separate targets from a prior 1:1 run) is consolidated on
+    // the next resolve: formatting-variant targets collapse into the most-imaged one.
+    [Fact]
+    public void EnsureTargetsResolved_ConsolidatesExistingVariantTargets_ByDominantSpelling()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var big = new Target { CanonicalName = "M101" };           // dominant spelling (more frames)
+            var small = new Target { CanonicalName = "M 101" };
+            db.Targets.AddRange(big, small);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = big });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = small });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M101",  Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="4", Path="/4", ObjectName="M 101", Type=ImageType.Light, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().ContainSingle();                      // the two variant targets merged
+        verify.Targets.Single().CanonicalName.Should().Be("M101");    // survivor = dominant spelling
+        verify.TargetNameMaps.Should().HaveCount(2);                  // both raw spellings still map...
+        verify.TargetNameMaps.Select(m => m.TargetId).Distinct().Should().ContainSingle(); // ...onto one target
+    }
+
+    // The Phase-B boundary: names that differ by real WORDS are NOT merged by light
+    // dedupe (no catalog knowledge). "Tarantula Nebula" vs "NGC 2070", and "Horsehead"
+    // vs "Horsehead Nebula", each stay separate until catalog resolution lands.
+    [Fact]
+    public void EnsureTargetsResolved_DifferentWordNames_StaySeparate()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Tarantula Nebula", Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="NGC 2070",         Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="c", Path="/c", ObjectName="Horsehead",        Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="d", Path="/d", ObjectName="Horsehead Nebula", Type=ImageType.Light, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.EnsureTargetsResolved();
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Select(t => t.CanonicalName).OrderBy(x => x)
+            .Should().BeEquivalentTo(new[] { "Horsehead", "Horsehead Nebula", "NGC 2070", "Tarantula Nebula" });
+    }
+
+    // A user TargetMerge whose SURVIVOR is later folded away by auto-consolidation must follow the
+    // consolidation (repointed onto the new survivor), not silently un-merge into a ghost record. The
+    // user merge's survivor ("M 101") is a formatting variant that consolidation folds into the
+    // dominant "M101"; the merge record must repoint from the variant onto "M101".
+    [Fact]
+    public void EnsureTargetsResolved_ConsolidationDeletesMergeSurvivor_RepointsMergeRecord()
+    {
+        int dominantId, variantId, absorbedId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var dominant = new Target { CanonicalName = "M101" };      // 3 frames -> consolidation survivor
+            var variant = new Target { CanonicalName = "M 101" };      // 1 frame -> folded away
+            var absorbed = new Target { CanonicalName = "Pinwheel" };  // cross-key; user-merged into the variant
+            db.Targets.AddRange(dominant, variant, absorbed);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M101", Target = dominant });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 101", Target = variant });
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "Pinwheel", Target = absorbed });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="1", Path="/1", ObjectName="M101",     Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="2", Path="/2", ObjectName="M101",     Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="3", Path="/3", ObjectName="M101",     Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="4", Path="/4", ObjectName="M 101",    Type=ImageType.Light, LibraryId=1 },
+                new ImageFile { HeaderHash="5", Path="/5", ObjectName="Pinwheel", Type=ImageType.Light, LibraryId=1 });
+            db.SaveChanges();
+            dominantId = dominant.Id; variantId = variant.Id; absorbedId = absorbed.Id;
+        }
+
+        var svc = new TargetResolutionService(new TestDbContextFactory(_fx.DatabaseFilename));
+        svc.MergeTargets(new[] { variantId, absorbedId }, "M 101");   // Pinwheel -> the variant (survivor)
+        svc.EnsureTargetsResolved();                                  // folds the variant into dominant
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Any(t => t.Id == variantId).Should().BeFalse();          // variant consolidated away
+        var record = verify.TargetMerges.Should().ContainSingle().Subject;
+        record.AbsorbedTargetId.Should().Be(absorbedId);
+        record.SurvivorTargetId.Should().Be(dominantId);                        // repointed onto the new survivor
+    }
+}

--- a/Lumidex.Tests/TargetSummaryViewModelTests.cs
+++ b/Lumidex.Tests/TargetSummaryViewModelTests.cs
@@ -1,0 +1,257 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Features.TargetSummary;
+using Lumidex.Services;
+using Lumidex.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Tests;
+
+// The schema is wiped/recreated per test so seeded rows never leak between tests.
+public class TargetSummaryViewModelTests : IClassFixture<DatabaseFixture>, IDisposable
+{
+    private readonly DatabaseFixture _fx;
+    public TargetSummaryViewModelTests(DatabaseFixture fx)
+    {
+        _fx = fx;
+        using var db = new LumidexDbContext(_fx.Options);
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+    }
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    private TargetSummaryViewModel BuildViewModel()
+    {
+        var factory = new TestDbContextFactory(_fx.DatabaseFilename);
+        return new TargetSummaryViewModel(factory, new TargetResolutionService(factory), new TargetGoalQuery(factory), new DialogService());
+    }
+
+    // A goal entered on a filter row persists to TargetFilterGoal for that (target, scope, filter).
+    [Fact]
+    public async Task SetFilterGoal_StoresGoalOnTargetScopeFilter()
+    {
+        int targetId;
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.Add(new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+            targetId = t.Id;
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var filter = vm.Targets.Single().Scopes.Single().Filters.Single();
+        filter.ExplicitGoal = 10;
+        await filter.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetFilterGoals.Single(g => g.TargetId == targetId && g.Scope == "T20" && g.Filter == "L")
+            .GoalHours.Should().Be(10);
+    }
+
+    // A zero (or cleared) goal deletes the filter's goal row — PercentComplete treats "no goal"
+    // as goal == acquired, so storing 0 would just be an ignored value.
+    [Fact]
+    public async Task SetFilterGoal_Zero_DeletesGoal()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.Add(new ImageFile { HeaderHash="a", Path="/a", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T20", Filter = "L", GoalHours = 10 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var filter = vm.Targets.Single().Scopes.Single().Filters.Single();
+        filter.ExplicitGoal = 0;
+        await filter.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetFilterGoals.Should().BeEmpty();
+    }
+
+    // Merging the selected target rows collapses them to one target.
+    [Fact]
+    public async Task MergeSelected_MergesSelectedTargets()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Andromeda", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=7200, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31",      Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        vm.Targets.Should().HaveCount(2);                 // distinct names stay separate
+        foreach (var t in vm.Targets) t.IsSelected = true;
+        await vm.MergeSelectedCommand.ExecuteAsync(null);
+
+        vm.Targets.Should().ContainSingle();              // the two rows fold to one in the view
+        vm.Targets.Single().CanonicalName.Should().Be("Andromeda"); // survivor = most-integrated (2h > 1h)
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.Targets.Should().HaveCount(2);             // non-destructive: both target rows remain on disk
+        verify.TargetMerges.Should().ContainSingle();     // the fold is a record, undoable
+    }
+
+    // F16: undoing the last merge from the flyout empties the list and flips the empty-state flag, so
+    // "No merges yet." shows and no orphaned row lingers. Exercises the MergeOperationRowViewModel
+    // UndoCommand callback path end to end (the flyout's actual binding).
+    [Fact]
+    public async Task UndoMerge_LastOperation_EmptiesPanelAndFlipsEmptyState()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="a", Path="/a", ObjectName="Andromeda", Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=7200, LibraryId=1 },
+                new ImageFile { HeaderHash="b", Path="/b", ObjectName="M 31",      Type=ImageType.Light, TelescopeName="T20", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        foreach (var t in vm.Targets) t.IsSelected = true;
+        await vm.MergeSelectedCommand.ExecuteAsync(null);
+        vm.MergeOperations.Should().ContainSingle();          // the merge shows in the panel
+        vm.HasNoMerges.Should().BeFalse();
+
+        await vm.MergeOperations.Single().UndoCommand.ExecuteAsync(null);
+
+        vm.MergeOperations.Should().BeEmpty();                // undo clears it
+        vm.HasNoMerges.Should().BeTrue();                     // empty-state flips
+        vm.Targets.Should().HaveCount(2);                     // and the rows re-separate
+    }
+
+    // Editing a FLIPPED cell (goal stored pre-flip as "Blue", cell renders "B") must update
+    // the stored row and re-key it to the rendered label — not strand it and insert a twin
+    // row for the same channel.
+    [Fact]
+    public async Task SetFilterGoal_OnFlippedCell_UpdatesPartnerRow_NoTwin()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="b1", Path="/b1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="B", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="v1", Path="/v1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="V", Exposure=1800, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "Blue", GoalHours = 10 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var b = vm.Targets.Single().Scopes.Single().Filters.Single(f => f.Filter == "B");
+        b.ExplicitGoal.Should().Be(10);                       // the flipped cell displays the stored goal
+        b.ExplicitGoal = 12;
+        await b.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        var row = verify.TargetFilterGoals.Should().ContainSingle().Which;   // updated, not twinned
+        row.Filter.Should().Be("B");                                          // re-keyed to the rendered label
+        row.GoalHours.Should().Be(12);
+    }
+
+    // Clearing a flipped cell must delete the partner-labelled row it displayed — leaving it
+    // stranded would resurrect the goal on the next reload.
+    [Fact]
+    public async Task SetFilterGoal_Zero_OnFlippedCell_DeletesPartnerRow()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.AddRange(
+                new ImageFile { HeaderHash="b1", Path="/b1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="B", Exposure=3600, LibraryId=1 },
+                new ImageFile { HeaderHash="v1", Path="/v1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30", FilterName="V", Exposure=1800, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30", Filter = "Blue", GoalHours = 10 });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var b = vm.Targets.Single().Scopes.Single().Filters.Single(f => f.Filter == "B");
+        b.ExplicitGoal = 0;
+        await b.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetFilterGoals.Should().BeEmpty();          // the pre-flip row is gone, no resurrection
+    }
+
+    // A goal stored under an ABSORBED scope name renders on the survivor's cell (the read side
+    // resolves merges); editing that cell must update the stored row in place — re-keyed to the
+    // survivor — not fork a second row under the survivor label.
+    [Fact]
+    public async Task SetFilterGoal_OnGoalUnderAbsorbedScope_UpdatesInPlace_NoTwin()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.Add(
+                new ImageFile { HeaderHash="a1", Path="/a1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30b", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30b", Filter = "L", GoalHours = 10 });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "T30b", CanonicalName = "T30" });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var l = vm.Targets.Single().Scopes.Single().Filters.Single(f => f.Filter == "L");
+        l.ExplicitGoal.Should().Be(10);                       // displayed via the merge remap
+        l.ExplicitGoal = 12;
+        await l.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        var row = verify.TargetFilterGoals.Should().ContainSingle().Which;   // updated, not forked
+        row.Scope.Should().Be("T30");                                         // re-keyed to the survivor
+        row.GoalHours.Should().Be(12);
+    }
+
+    // Clearing a goal displayed via the merge remap must delete the pre-merge row — the
+    // pre-fix literal-key search found nothing, silently no-op'd, and the goal resurrected.
+    [Fact]
+    public async Task SetFilterGoal_Zero_OnGoalUnderAbsorbedScope_DeletesIt()
+    {
+        using (var db = new LumidexDbContext(_fx.Options))
+        {
+            db.Libraries.Add(new Library { Id = 1, Name = "Lib", Path = "/lib" });
+            var t = new Target { CanonicalName = "M 31" };
+            db.Targets.Add(t);
+            db.TargetNameMaps.Add(new TargetNameMap { RawObjectName = "M 31", Target = t });
+            db.ImageFiles.Add(
+                new ImageFile { HeaderHash="a1", Path="/a1", ObjectName="M 31", Type=ImageType.Light, TelescopeName="T30b", FilterName="L", Exposure=3600, LibraryId=1 });
+            db.TargetFilterGoals.Add(new TargetFilterGoal { Target = t, Scope = "T30b", Filter = "L", GoalHours = 10 });
+            db.ScopeMerges.Add(new ScopeMerge { OperationId = Guid.NewGuid(), AbsorbedName = "T30b", CanonicalName = "T30" });
+            db.SaveChanges();
+        }
+
+        var vm = BuildViewModel();
+        await vm.Reload();
+        var l = vm.Targets.Single().Scopes.Single().Filters.Single(f => f.Filter == "L");
+        l.ExplicitGoal = 0;
+        await l.SetGoalCommand.ExecuteAsync(null);
+
+        using var verify = new LumidexDbContext(_fx.Options);
+        verify.TargetFilterGoals.Should().BeEmpty();          // deleted through the merge remap
+    }
+}

--- a/Lumidex/Converters/FilterColorConverter.cs
+++ b/Lumidex/Converters/FilterColorConverter.cs
@@ -1,0 +1,71 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using System.Globalization;
+
+namespace Lumidex.Converters;
+
+// Maps a filter's CANONICAL label to its bar-segment color. The filter names are
+// already folded to canonical labels upstream by
+// Lumidex.Core.Targets.FilterCanonicalizer (so "H"/"Ha" arrive here as "Ha", and a
+// telescope's photometric "B" arrives distinct from imaging "Blue") — this
+// converter only owns the label -> color mapping, not the folding. Any label not
+// in the palette (including the "(No filter)" bucket and genuinely unknown
+// filters) falls back to a neutral gray so every segment still renders. Returns an
+// IBrush so it binds straight to a Rectangle Fill with no second converter.
+//
+// Colors are grouped by the two filter systems the canonicalizer distinguishes:
+//   - Imaging: Luminance, RGB, the SHO + extra narrowbands, OSC "Color", and the
+//     multiband filters, each its own color.
+//   - Photometric (Johnson-Cousins U B V R I): deliberately shifted shades of the
+//     same hue family as their imaging cousins, so a photometric "B"/"R" reads as
+//     blue/red but is visibly distinct from imaging "Blue"/"Red".
+public class FilterColorConverter : IValueConverter
+{
+    public static readonly FilterColorConverter Instance = new();
+
+    private static readonly IBrush Default = new ImmutableSolidColorBrush(Color.Parse("#8a8f99"));
+
+    // Keyed case-insensitively as a safety net; the canonicalizer already emits a
+    // stable casing per label.
+    private static readonly Dictionary<string, IBrush> Palette =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Imaging — broadband
+            ["L"] = Brush("#d8dde6"),
+            ["Red"] = Brush("#e0524e"),
+            ["Green"] = Brush("#56c073"),
+            ["Blue"] = Brush("#5b8def"),
+            // Imaging — narrowband
+            ["Ha"] = Brush("#b3304d"),
+            ["OIII"] = Brush("#1fb6a8"),
+            ["SII"] = Brush("#d9a441"),
+            ["Hb"] = Brush("#45b6d8"),
+            ["He"] = Brush("#8e6fd0"),
+            ["NII"] = Brush("#e07a3c"),
+            // Imaging — one-shot-color + multiband (per-product colors)
+            ["Color"] = Brush("#b89ad0"),
+            ["LPro"] = Brush("#aab3c0"),
+            ["LUltimate"] = Brush("#b154a6"),
+            ["L-eNhance"] = Brush("#5bbf9e"),
+            // Photometric (Johnson-Cousins) — shifted shades, distinct from imaging
+            ["U"] = Brush("#6a4fb0"),
+            ["B"] = Brush("#2f4bb0"),
+            ["V"] = Brush("#9cbf3a"),
+            ["R"] = Brush("#a83228"),
+            ["I"] = Brush("#6e2b2b"),
+        };
+
+    private static IBrush Brush(string hex) => new ImmutableSolidColorBrush(Color.Parse(hex));
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string s && Palette.TryGetValue(s.Trim(), out var brush))
+            return brush;
+
+        return Default;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Lumidex/Converters/IntegrationBarWidthConverter.cs
+++ b/Lumidex/Converters/IntegrationBarWidthConverter.cs
@@ -1,0 +1,37 @@
+using Avalonia.Data.Converters;
+using System.Globalization;
+
+namespace Lumidex.Converters;
+
+// Computes a filter segment's pixel width for the target integration bar.
+// Inputs (MultiBinding order): [segment hours, row GoalHours, parent MaxTotalHours,
+// track pixel width]. The denominator is the goal when one is set, otherwise the
+// largest target's total (the "relative to your biggest target" fallback from the
+// spec). Width = (hours / denominator) * trackWidth, clamped to the track so a
+// target that overshoots its goal can't paint past the bar. The unfilled remainder
+// is the track Border's own background showing through behind the segments, so no
+// explicit "empty tail" element is needed.
+public class IntegrationBarWidthConverter : IMultiValueConverter
+{
+    public static readonly IntegrationBarWidthConverter Instance = new();
+
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        // Bindings can deliver UnsetValue mid-layout; treat anything non-numeric as 0.
+        double hours = AsDouble(values.ElementAtOrDefault(0));
+        double? goal = AsNullableDouble(values.ElementAtOrDefault(1));
+        double max = AsDouble(values.ElementAtOrDefault(2));
+        double trackWidth = AsDouble(values.ElementAtOrDefault(3));
+
+        double denominator = goal is > 0 ? goal.Value : max;
+        if (denominator <= 0 || trackWidth <= 0)
+            return 0d;
+
+        double width = hours / denominator * trackWidth;
+        return Math.Clamp(width, 0d, trackWidth);
+    }
+
+    private static double AsDouble(object? value) => value is double d ? d : 0d;
+
+    private static double? AsNullableDouble(object? value) => value as double?;
+}

--- a/Lumidex/Converters/TargetSummarySortLabelConverter.cs
+++ b/Lumidex/Converters/TargetSummarySortLabelConverter.cs
@@ -1,0 +1,26 @@
+using Avalonia.Data.Converters;
+using Lumidex.Features.TargetSummary;
+using System.Globalization;
+
+namespace Lumidex.Converters;
+
+// Maps the TargetSummarySort enum to a human-readable label for the sort dropdown (the raw
+// enum names — "DataAcquired" etc. — read poorly in the UI).
+public class TargetSummarySortLabelConverter : IValueConverter
+{
+    public static readonly TargetSummarySortLabelConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
+    {
+        TargetSummarySort.Alphabetical => "Alphabetical",
+        TargetSummarySort.DataAcquired => "Total Data Acquired",
+        TargetSummarySort.DataNeeded => "Data Needed",
+        TargetSummarySort.Goal => "Goal",
+        TargetSummarySort.FirstAcquired => "First Acquired",
+        TargetSummarySort.LastAcquired => "Most Recent",
+        _ => value?.ToString(),
+    };
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Lumidex/Features/Main/MainViewModel.cs
+++ b/Lumidex/Features/Main/MainViewModel.cs
@@ -8,6 +8,7 @@ using Lumidex.Features.MainSearch;
 using Lumidex.Features.Plot;
 using Lumidex.Features.Settings;
 using Lumidex.Features.SideNavBar;
+using Lumidex.Features.TargetSummary;
 using Lumidex.Features.Tags;
 using Lumidex.Services;
 
@@ -24,6 +25,7 @@ public partial class MainViewModel : ViewModelBase,
     private readonly TagManagerViewModel _tagManagerViewModel;
     private readonly LibraryManagerViewModel _libraryManagerViewModel;
     private readonly PlotManagerViewModel _plotManagerViewModel;
+    private readonly TargetSummaryViewModel _targetSummaryViewModel;
     private readonly MainSettingsViewModel _settingsViewModel;
 
     [ObservableProperty]
@@ -45,6 +47,7 @@ public partial class MainViewModel : ViewModelBase,
         TagManagerViewModel tagManagerViewModel,
         LibraryManagerViewModel libraryManagerViewModel,
         PlotManagerViewModel plotManagerViewModel,
+        TargetSummaryViewModel targetSummaryViewModel,
         MainSettingsViewModel settingsViewModel)
     {
         _systemService = systemService;
@@ -56,6 +59,7 @@ public partial class MainViewModel : ViewModelBase,
         _tagManagerViewModel = tagManagerViewModel;
         _libraryManagerViewModel = libraryManagerViewModel;
         _plotManagerViewModel = plotManagerViewModel;
+        _targetSummaryViewModel = targetSummaryViewModel;
         _settingsViewModel = settingsViewModel;
 
         // 28px for MacOS so traffic light is vertically centered.
@@ -89,6 +93,7 @@ public partial class MainViewModel : ViewModelBase,
             SideNavBarViewModel.TagsTabName => _tagManagerViewModel,
             SideNavBarViewModel.LibraryTabName => _libraryManagerViewModel,
             SideNavBarViewModel.PlotTabName => _plotManagerViewModel,
+            SideNavBarViewModel.TargetsTabName => _targetSummaryViewModel,
             // Lower Tabs
             SideNavBarViewModel.SettingsTabName => _settingsViewModel,
             _ => throw new NotImplementedException(),

--- a/Lumidex/Features/SideNavBar/SideNavBarViewModel.cs
+++ b/Lumidex/Features/SideNavBar/SideNavBarViewModel.cs
@@ -11,6 +11,7 @@ public partial class SideNavBarViewModel : ViewModelBase,
     public const string TagsTabName = "Tags";
     public const string LibraryTabName = "Library";
     public const string PlotTabName = "Plot";
+    public const string TargetsTabName = "Targets";
 
     // Lower Tabs
     public const string SettingsTabName = "Settings";
@@ -44,6 +45,12 @@ public partial class SideNavBarViewModel : ViewModelBase,
                 Name = PlotTabName,
                 ToolTipText = "Plot your data",
                 Icon = "mdi-chart-line",
+            },
+            new()
+            {
+                Name = TargetsTabName,
+                ToolTipText = "Track integration toward goals",
+                Icon = "mdi-target",
             },
             new()
             {

--- a/Lumidex/Features/TargetSummary/MergeOperationRowViewModel.cs
+++ b/Lumidex/Features/TargetSummary/MergeOperationRowViewModel.cs
@@ -1,0 +1,24 @@
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Features.TargetSummary;
+
+// One row in the "Manage merges" flyout: a user merge (scope or target) with a human label and the
+// OperationId needed to reverse it. The Undo button binds to this row's own UndoCommand (a callback
+// the VM assigns), not an ancestor binding — same pattern as the filter row's goal persistence.
+public partial class MergeOperationRowViewModel : ObservableObject
+{
+    public required Guid OperationId { get; init; }
+    public required MergeKind Kind { get; init; }
+
+    // e.g. "iTelescope 75 → iTelescope T75" (scope) or "Barnard 33 → Horsehead" (target).
+    public required string Label { get; init; }
+
+    // A short tag shown beside the label so scope vs target merges are distinguishable at a glance.
+    public string KindLabel => Kind == MergeKind.Scope ? "Scopes" : "Targets";
+
+    // Assigned by the VM; invoked by the Undo button to remove the records and reload.
+    public Func<MergeOperationRowViewModel, Task>? UndoAction { get; set; }
+
+    [RelayCommand]
+    private Task Undo() => UndoAction?.Invoke(this) ?? Task.CompletedTask;
+}

--- a/Lumidex/Features/TargetSummary/TargetGoalRowViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetGoalRowViewModel.cs
@@ -1,0 +1,140 @@
+using Lumidex.Core.Targets;
+
+namespace Lumidex.Features.TargetSummary;
+
+// One colored slice of a progress bar: a filter's acquired hours. The bar's filled portion is
+// these segments; the unfilled tail is the row's Remainder (the bar's "full" point − acquired).
+public record BarSegment(string Filter, double Hours);
+
+// A filter row — the ONLY level with an editable goal. When a goal is set the bar tracks
+// progress toward it and the % shows; when unset, the bar instead scales to the largest target
+// (ReferenceMax, an absolute "compare by data" view) and no goal/percent is shown.
+public partial class FilterGoalRowViewModel : ObservableObject
+{
+    public required int TargetId { get; init; }
+    public required string Scope { get; init; }
+    public required string Filter { get; init; }
+    public required double Hours { get; init; }
+
+    // The reference for an UNSET bar (the largest target's hours); set by the VM each load.
+    public double ReferenceMax { get; set; }
+
+    // Editable explicit goal; null/0 = unset.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasGoal))]
+    [NotifyPropertyChangedFor(nameof(EffectiveGoal))]
+    [NotifyPropertyChangedFor(nameof(BarGoal))]
+    [NotifyPropertyChangedFor(nameof(PercentComplete))]
+    [NotifyPropertyChangedFor(nameof(Remainder))]
+    public partial double? ExplicitGoal { get; set; }
+
+    public bool HasGoal => ExplicitGoal is > 0;
+    // For roll-up: an unset filter contributes its acquired hours to the derived parent goal.
+    public double EffectiveGoal => HasGoal ? ExplicitGoal!.Value : Hours;
+    // The bar's "full" point: the goal when set, else the largest-target reference (absolute view).
+    public double BarGoal => HasGoal ? EffectiveGoal : ReferenceMax;
+    public double Remainder => Math.Max(0, BarGoal - Hours);   // unfilled tail (clamped, never negative)
+    public double? PercentComplete => HasGoal ? Math.Min(100, Hours / EffectiveGoal * 100) : null;
+
+    public IReadOnlyList<BarSegment> Segments => [new BarSegment(Filter, Hours)];
+
+    // True when this row's bare-B/R flip partner (see FilterCanonicalizer.FlipPartnerOf) has no
+    // sibling cell on the same scope — set by the VM at build. Lets a goal edit UPDATE a row
+    // stored under the partner label (saved before the scope's filter context flipped) instead
+    // of stranding it and inserting a twin row for the same channel.
+    public bool AllowFlipPartnerMatch { get; set; }
+
+    // Persists this filter's goal; assigned by TargetSummaryViewModel. A callback (not a binding
+    // to the parent VM) because the row lives in the expander's deferred template, where an
+    // ancestor/#element binding crashes Avalonia's binding-error logger.
+    public Func<FilterGoalRowViewModel, Task>? PersistGoal { get; set; }
+
+    // Re-raises the parent scope + target derived properties so their bars/goals update live
+    // when this filter's goal changes, WITHOUT a full reload (set by the VM during build). The
+    // full reload was collapsing the tree and stealing focus from the next goal box.
+    public Action? RaiseAncestors { get; set; }
+
+    [RelayCommand]
+    private Task SetGoal() => PersistGoal?.Invoke(this) ?? Task.CompletedTask;
+}
+
+// A scope (telescope) row. Hours/Goal are derived sums of its filters; it expands to show its
+// filters. HasGoal is true once any filter beneath it carries an explicit goal.
+public partial class ScopeGoalRowViewModel : ObservableObject
+{
+    public required string Scope { get; init; }
+    public required IReadOnlyList<FilterGoalRowViewModel> Filters { get; init; }
+    public DateTime? First { get; init; }
+    public DateTime? Last { get; init; }
+    public double ReferenceMax { get; set; }
+
+    [ObservableProperty] public partial bool IsExpanded { get; set; }
+    // Checked in the expanded scope list to fold this scope's telescope name into another's.
+    [ObservableProperty] public partial bool IsSelected { get; set; }
+
+    public bool HasGoal => Filters.Any(f => f.HasGoal);
+    public double Hours => Filters.Sum(f => f.Hours);
+    public double Goal => Filters.Sum(f => f.EffectiveGoal);
+    public double BarGoal => HasGoal ? Goal : ReferenceMax;
+    public double Remainder => Math.Max(0, BarGoal - Hours);
+    public double? PercentComplete => HasGoal ? Math.Min(100, Hours / Goal * 100) : null;
+    public IReadOnlyList<BarSegment> Segments => Filters.Select(f => new BarSegment(f.Filter, f.Hours)).ToList();
+
+    // Re-raise the goal-derived properties (the bar + numbers) after a child filter's goal
+    // changes — an in-memory live update instead of rebuilding the row. Hours/Segments are
+    // unaffected by a goal edit, so they're not raised.
+    public void RaiseDerived()
+    {
+        OnPropertyChanged(nameof(HasGoal));
+        OnPropertyChanged(nameof(Goal));
+        OnPropertyChanged(nameof(BarGoal));
+        OnPropertyChanged(nameof(Remainder));
+        OnPropertyChanged(nameof(PercentComplete));
+    }
+}
+
+// A canonical target row. A single-scope target hides the scope layer (CanExpand false) and
+// shows its filters directly; multi-scope targets expand into independently-expandable scopes.
+public partial class TargetGoalRowViewModel : ObservableObject
+{
+    public required int TargetId { get; init; }
+    public required string CanonicalName { get; init; }
+    public required IReadOnlyList<ScopeGoalRowViewModel> Scopes { get; init; }
+    public DateTime? First { get; init; }
+    public DateTime? Last { get; init; }
+    public double ReferenceMax { get; set; }
+
+    [ObservableProperty] public partial bool IsSelected { get; set; }
+    [ObservableProperty] public partial bool IsExpanded { get; set; }
+
+    public bool HasGoal => Scopes.Any(s => s.HasGoal);
+    public double Hours => Scopes.Sum(s => s.Hours);
+    public double Goal => Scopes.Sum(s => s.Goal);
+    public double BarGoal => HasGoal ? Goal : ReferenceMax;
+    public double Remainder => Math.Max(0, BarGoal - Hours);
+    public double? PercentComplete => HasGoal ? Math.Min(100, Hours / Goal * 100) : null;
+
+    // Only multi-scope targets expand into a scope layer; single-scope shows filters directly.
+    public bool CanExpand => Scopes.Count > 1;
+    public IReadOnlyList<FilterGoalRowViewModel> Filters => Scopes.Count == 1 ? Scopes[0].Filters : [];
+
+    // Target-level bar segments: each canonical filter's hours summed across scopes, in the
+    // classifier's order so the colored bar reads in the standard filter sequence.
+    public IReadOnlyList<BarSegment> Segments => Scopes
+        .SelectMany(s => s.Filters)
+        .GroupBy(f => f.Filter)
+        .Select(g => new BarSegment(g.Key, g.Sum(f => f.Hours)))
+        .OrderBy(b => FilterClassifier.SortKey(b.Filter))
+        .ToList();
+
+    // Live in-memory update of the goal-derived properties after a descendant filter's goal
+    // changes (Hours/Segments unaffected by a goal edit, so not raised).
+    public void RaiseDerived()
+    {
+        OnPropertyChanged(nameof(HasGoal));
+        OnPropertyChanged(nameof(Goal));
+        OnPropertyChanged(nameof(BarGoal));
+        OnPropertyChanged(nameof(Remainder));
+        OnPropertyChanged(nameof(PercentComplete));
+    }
+}

--- a/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
+++ b/Lumidex/Features/TargetSummary/TargetSummaryView.axaml
@@ -1,0 +1,378 @@
+<UserControl
+    x:Class="Lumidex.Features.TargetSummary.TargetSummaryView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converter="using:Lumidex.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:i="https://github.com/projektanker/icons.avalonia"
+    xmlns:ie="using:Avalonia.Xaml.Interactions.Custom"
+    xmlns:interactivity="using:Avalonia.Xaml.Interactivity"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ts="using:Lumidex.Features.TargetSummary"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:DataType="ts:TargetSummaryViewModel"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <converter:NullableDecimalToDoubleConverter x:Key="DecimalToDouble" />
+    </UserControl.Resources>
+
+    <!-- Implicit data template (in DataTemplates, not Resources, so it applies by type) for the
+         filter row — the ONLY level with an editable goal. Both the per-scope and single-scope
+         filter lists below pick it up. Every binding reads off the row's own DataContext (the
+         SetGoalCommand, the bar's Segments/Remainder) — never an ancestor/#element binding, which
+         crashes Avalonia's binding-error logger in these deferred expander templates. -->
+    <UserControl.DataTemplates>
+        <DataTemplate DataType="ts:FilterGoalRowViewModel">
+            <Grid Margin="0,1" ColumnDefinitions="32,210,160,*,46">
+                <TextBlock
+                    Grid.Column="1"
+                    Margin="28,0,0,0"
+                    VerticalAlignment="Center"
+                    Opacity="0.8"
+                    Text="{Binding Filter}" />
+                <StackPanel
+                    Grid.Column="2"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal"
+                    Spacing="4">
+                    <TextBlock
+                        Width="52"
+                        VerticalAlignment="Center"
+                        Opacity="0.8"
+                        TextAlignment="Right"
+                        Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                    <NumericUpDown
+                        Width="84"
+                        VerticalAlignment="Center"
+                        Increment="1"
+                        Minimum="0"
+                        ShowButtonSpinner="False"
+                        Value="{Binding ExplicitGoal, Converter={StaticResource DecimalToDouble}}"
+                        Watermark="goal">
+                        <interactivity:Interaction.Behaviors>
+                            <ie:ExecuteCommandOnLostFocusBehavior Command="{Binding SetGoalCommand}" />
+                        </interactivity:Interaction.Behaviors>
+                    </NumericUpDown>
+                </StackPanel>
+                <Border
+                    Grid.Column="3"
+                    Height="14"
+                    MinWidth="80"
+                    Margin="8,0"
+                    VerticalAlignment="Center"
+                    Background="#22FFFFFF"
+                    ClipToBounds="True"
+                    CornerRadius="4">
+                    <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                        <StackPanel Orientation="Horizontal">
+                            <ItemsControl ItemsSource="{Binding Segments}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="ts:BarSegment">
+                                        <Rectangle
+                                            Height="12"
+                                            Width="{Binding Hours}"
+                                            Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                            ToolTip.Tip="{Binding Filter}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Rectangle Height="12" Width="{Binding Remainder}" Fill="Transparent" />
+                        </StackPanel>
+                    </Viewbox>
+                </Border>
+                <TextBlock
+                    Grid.Column="4"
+                    VerticalAlignment="Center"
+                    Opacity="0.8"
+                    TextAlignment="Right"
+                    Text="{Binding PercentComplete, StringFormat='{}{0:0}%', TargetNullValue='—', FallbackValue='—'}" />
+            </Grid>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <DockPanel Margin="8">
+        <!-- Toolbar: merge, refresh, and the per-layer sort control (filters stay static). -->
+        <StackPanel
+            Margin="0,0,0,8"
+            DockPanel.Dock="Top"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button
+                Classes="accent"
+                Command="{Binding MergeSelectedCommand}"
+                Content="Merge Targets"
+                ToolTip.Tip="Combine the selected target rows into one. Non-destructive — undo any time from Manage merges." />
+            <Button
+                Command="{Binding MergeScopesCommand}"
+                Content="Merge Scopes"
+                ToolTip.Tip="Combine selected scope rows (telescope-name variants, e.g. &quot;iTelescope 75&quot; and &quot;iTelescope T75&quot;) into one. Expand a target and check two scope rows. Non-destructive — undo from Manage merges." />
+            <Button Content="Manage merges…">
+                <Button.Flyout>
+                    <Flyout Placement="Bottom">
+                        <Border Width="380" Padding="4">
+                            <StackPanel Spacing="6">
+                                <TextBlock FontWeight="SemiBold" Text="Merges" />
+                                <TextBlock
+                                    IsVisible="{Binding HasNoMerges}"
+                                    Opacity="0.7"
+                                    Text="No merges yet." />
+                                <ItemsControl ItemsSource="{Binding MergeOperations}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="ts:MergeOperationRowViewModel">
+                                            <Grid Margin="0,2" ColumnDefinitions="58,*,Auto">
+                                                <Border
+                                                    Grid.Column="0"
+                                                    Margin="0,0,6,0"
+                                                    Padding="4,1"
+                                                    VerticalAlignment="Center"
+                                                    Background="#22FFFFFF"
+                                                    CornerRadius="3">
+                                                    <TextBlock
+                                                        FontSize="11"
+                                                        HorizontalAlignment="Center"
+                                                        Opacity="0.8"
+                                                        Text="{Binding KindLabel}" />
+                                                </Border>
+                                                <TextBlock
+                                                    Grid.Column="1"
+                                                    VerticalAlignment="Center"
+                                                    Text="{Binding Label}"
+                                                    TextTrimming="CharacterEllipsis"
+                                                    ToolTip.Tip="{Binding Label}" />
+                                                <Button
+                                                    Grid.Column="2"
+                                                    Margin="6,0,0,0"
+                                                    Command="{Binding UndoCommand}"
+                                                    Content="Undo" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+            <Button Command="{Binding RefreshCommand}" Content="Refresh" />
+            <TextBlock VerticalAlignment="Center" Text="Sort:" />
+            <ComboBox
+                MinWidth="160"
+                VerticalAlignment="Center"
+                ItemsSource="{Binding SortOptions}"
+                SelectedItem="{Binding SortBy}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Converter={x:Static converter:TargetSummarySortLabelConverter.Instance}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ToggleButton
+                VerticalAlignment="Center"
+                IsChecked="{Binding SortAscending}"
+                ToolTip.Tip="Ascending / descending">
+                <Panel>
+                    <i:Icon FontSize="16" IsVisible="{Binding SortAscending}" Value="mdi-sort-ascending" />
+                    <i:Icon FontSize="16" IsVisible="{Binding !SortAscending}" Value="mdi-sort-descending" />
+                </Panel>
+            </ToggleButton>
+        </StackPanel>
+
+        <ScrollViewer>
+            <ItemsControl x:Name="TargetsList" ItemsSource="{Binding Targets}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="ts:TargetGoalRowViewModel">
+                        <StackPanel>
+                            <!-- Target row. Same lane geometry as the scope/filter rows so the
+                                 bars line up. Goal here is the derived rolled-up goal (no field). -->
+                            <Grid Margin="0,3" ColumnDefinitions="32,210,160,*,46">
+                                <CheckBox
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    IsChecked="{Binding IsSelected}"
+                                    ToolTip.Tip="Select for merge" />
+                                <DockPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <ToggleButton
+                                        DockPanel.Dock="Left"
+                                        Margin="0,0,4,0"
+                                        Padding="2,0"
+                                        VerticalAlignment="Center"
+                                        Background="Transparent"
+                                        IsChecked="{Binding IsExpanded}"
+                                        ToolTip.Tip="Show the per-filter breakdown">
+                                        <i:Icon FontSize="14" Value="mdi-chevron-right" />
+                                    </ToggleButton>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        FontWeight="SemiBold"
+                                        Text="{Binding CanonicalName}"
+                                        TextTrimming="CharacterEllipsis"
+                                        ToolTip.Tip="{Binding CanonicalName}" />
+                                </DockPanel>
+                                <StackPanel
+                                    Grid.Column="2"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal"
+                                    Spacing="4">
+                                    <TextBlock
+                                        Width="52"
+                                        VerticalAlignment="Center"
+                                        TextAlignment="Right"
+                                        Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                                    <TextBlock IsVisible="{Binding HasGoal}" VerticalAlignment="Center" Text="/" />
+                                    <TextBlock
+                                        Width="52"
+                                        VerticalAlignment="Center"
+                                        IsVisible="{Binding HasGoal}"
+                                        TextAlignment="Right"
+                                        Text="{Binding Goal, StringFormat='{}{0:0.0}h'}" />
+                                </StackPanel>
+                                <Border
+                                    Grid.Column="3"
+                                    Height="16"
+                                    MinWidth="80"
+                                    Margin="8,0"
+                                    VerticalAlignment="Center"
+                                    Background="#22FFFFFF"
+                                    ClipToBounds="True"
+                                    CornerRadius="4">
+                                    <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                                        <StackPanel Orientation="Horizontal">
+                                            <ItemsControl ItemsSource="{Binding Segments}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="ts:BarSegment">
+                                                        <Rectangle
+                                                            Height="14"
+                                                            Width="{Binding Hours}"
+                                                            Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                                            ToolTip.Tip="{Binding Filter}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                            <Rectangle Height="14" Width="{Binding Remainder}" Fill="Transparent" />
+                                        </StackPanel>
+                                    </Viewbox>
+                                </Border>
+                                <TextBlock
+                                    Grid.Column="4"
+                                    VerticalAlignment="Center"
+                                    TextAlignment="Right"
+                                    Text="{Binding PercentComplete, StringFormat='{}{0:0}%', TargetNullValue='—', FallbackValue='—'}" />
+                            </Grid>
+
+                            <!-- Expanded breakdown: scope rows (multi-scope) each followed by its
+                                 filters, OR the filters directly (single-scope). -->
+                            <StackPanel Margin="0,0,0,4" IsVisible="{Binding IsExpanded}">
+                                <ItemsControl IsVisible="{Binding CanExpand}" ItemsSource="{Binding Scopes}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="ts:ScopeGoalRowViewModel">
+                                            <StackPanel>
+                                                <!-- Scope header (derived goal, no field). -->
+                                                <Grid Margin="0,4,0,1" ColumnDefinitions="32,210,160,*,46">
+                                                    <CheckBox
+                                                        Grid.Column="0"
+                                                        Margin="6,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        IsChecked="{Binding IsSelected}"
+                                                        ToolTip.Tip="Select for scope merge" />
+                                                    <DockPanel Grid.Column="1" Margin="14,0,0,0" VerticalAlignment="Center">
+                                                        <ToggleButton
+                                                            DockPanel.Dock="Left"
+                                                            Margin="0,0,4,0"
+                                                            Padding="2,0"
+                                                            VerticalAlignment="Center"
+                                                            Background="Transparent"
+                                                            IsChecked="{Binding IsExpanded}"
+                                                            ToolTip.Tip="Show filters">
+                                                            <i:Icon FontSize="12" Value="mdi-chevron-right" />
+                                                        </ToggleButton>
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            FontWeight="SemiBold"
+                                                            Opacity="0.9"
+                                                            Text="{Binding Scope}" />
+                                                    </DockPanel>
+                                                    <StackPanel
+                                                        Grid.Column="2"
+                                                        VerticalAlignment="Center"
+                                                        Orientation="Horizontal"
+                                                        Spacing="4">
+                                                        <TextBlock
+                                                            Width="52"
+                                                            VerticalAlignment="Center"
+                                                            Opacity="0.9"
+                                                            TextAlignment="Right"
+                                                            Text="{Binding Hours, StringFormat='{}{0:0.0}h'}" />
+                                                        <TextBlock IsVisible="{Binding HasGoal}" VerticalAlignment="Center" Opacity="0.9" Text="/" />
+                                                        <TextBlock
+                                                            Width="52"
+                                                            VerticalAlignment="Center"
+                                                            IsVisible="{Binding HasGoal}"
+                                                            Opacity="0.9"
+                                                            TextAlignment="Right"
+                                                            Text="{Binding Goal, StringFormat='{}{0:0.0}h'}" />
+                                                    </StackPanel>
+                                                    <Border
+                                                        Grid.Column="3"
+                                                        Height="14"
+                                                        MinWidth="80"
+                                                        Margin="8,0"
+                                                        VerticalAlignment="Center"
+                                                        Background="#22FFFFFF"
+                                                        ClipToBounds="True"
+                                                        CornerRadius="4">
+                                                        <Viewbox HorizontalAlignment="Stretch" Stretch="Fill" StretchDirection="Both">
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <ItemsControl ItemsSource="{Binding Segments}">
+                                                                    <ItemsControl.ItemsPanel>
+                                                                        <ItemsPanelTemplate>
+                                                                            <StackPanel Orientation="Horizontal" />
+                                                                        </ItemsPanelTemplate>
+                                                                    </ItemsControl.ItemsPanel>
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate DataType="ts:BarSegment">
+                                                                            <Rectangle
+                                                                                Height="12"
+                                                                                Width="{Binding Hours}"
+                                                                                Fill="{Binding Filter, Converter={x:Static converter:FilterColorConverter.Instance}}"
+                                                                                ToolTip.Tip="{Binding Filter}" />
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                                <Rectangle Height="12" Width="{Binding Remainder}" Fill="Transparent" />
+                                                            </StackPanel>
+                                                        </Viewbox>
+                                                    </Border>
+                                                    <TextBlock
+                                                        Grid.Column="4"
+                                                        VerticalAlignment="Center"
+                                                        Opacity="0.9"
+                                                        TextAlignment="Right"
+                                                        Text="{Binding PercentComplete, StringFormat='{}{0:0}%', TargetNullValue='—', FallbackValue='—'}" />
+                                                </Grid>
+                                                <!-- The scope's filters (implicit template), shown when the scope is expanded. -->
+                                                <ItemsControl IsVisible="{Binding IsExpanded}" ItemsSource="{Binding Filters}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <!-- Single-scope target: its filters directly under it. -->
+                                <ItemsControl IsVisible="{Binding !CanExpand}" ItemsSource="{Binding Filters}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</UserControl>

--- a/Lumidex/Features/TargetSummary/TargetSummaryView.axaml.cs
+++ b/Lumidex/Features/TargetSummary/TargetSummaryView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace Lumidex.Features.TargetSummary;
+
+public partial class TargetSummaryView : UserControl
+{
+    public TargetSummaryView() => InitializeComponent();
+}

--- a/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
+++ b/Lumidex/Features/TargetSummary/TargetSummaryViewModel.cs
@@ -1,0 +1,378 @@
+using Lumidex.Core.Data;
+using Lumidex.Core.Targets;
+using Lumidex.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lumidex.Features.TargetSummary;
+
+// The per-layer sort keys (the dropdown). Filter rows are exempt — they always use the
+// FilterClassifier's static order.
+public enum TargetSummarySort { Alphabetical, DataAcquired, DataNeeded, Goal, FirstAcquired, LastAcquired }
+
+public partial class TargetSummaryViewModel : ViewModelBase
+{
+    private readonly IDbContextFactory<LumidexDbContext> _dbContextFactory;
+    private readonly TargetResolutionService _resolution;
+    private readonly TargetGoalQuery _query;
+    private readonly DialogService _dialogService;
+    // Serializes the DB-writing paths (Reload's resolve, a goal write, MergeSelected) so a
+    // background reload and a user edit don't hit the same SQLite file at once → SQLITE_BUSY.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _loaded;   // gate the sort-change reload until the first activation has run
+
+    // Reassigned wholesale on each load (the codebase's bulk-replace pattern); a fresh
+    // collection + one rebind avoids the ItemsControl range-notification crash.
+    [ObservableProperty] public partial ObservableCollectionEx<TargetGoalRowViewModel> Targets { get; set; } = new();
+
+    // The active user merges, for the "Manage merges" flyout. Rebuilt each reload (so it reflects a
+    // just-made merge or an undo) alongside Targets.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasNoMerges))]
+    public partial ObservableCollectionEx<MergeOperationRowViewModel> MergeOperations { get; set; } = new();
+
+    // Drives the flyout's "No merges yet." empty state; re-raised when MergeOperations is reassigned.
+    public bool HasNoMerges => MergeOperations.Count == 0;
+
+    // The sort control. Changing either re-sorts every layer (filters stay static). Default is
+    // Alphabetical ascending; persisting the choice between sessions is a follow-up.
+    [ObservableProperty] public partial TargetSummarySort SortBy { get; set; } = TargetSummarySort.DataAcquired;
+    [ObservableProperty] public partial bool SortAscending { get; set; } = false;
+
+    public IReadOnlyList<TargetSummarySort> SortOptions { get; } = Enum.GetValues<TargetSummarySort>();
+
+    public TargetSummaryViewModel(
+        IDbContextFactory<LumidexDbContext> dbContextFactory,
+        TargetResolutionService resolution,
+        TargetGoalQuery query,
+        DialogService dialogService)
+    {
+        _dbContextFactory = dbContextFactory;
+        _resolution = resolution;
+        _query = query;
+        _dialogService = dialogService;
+    }
+
+    partial void OnSortByChanged(TargetSummarySort value) { if (_loaded) _ = Reload(); }
+    partial void OnSortAscendingChanged(bool value) { if (_loaded) _ = Reload(); }
+
+    // Re-resolve names, query the goal tree, and rebuild the rows. async Task so a DB failure
+    // awaits a dialog instead of crashing the tab; preserves which targets were expanded.
+    public async Task Reload()
+    {
+        try
+        {
+            var expanded = Targets.Where(t => t.IsExpanded).Select(t => t.TargetId).ToHashSet();
+            var expandedScopes = Targets
+                .SelectMany(t => t.Scopes.Where(s => s.IsExpanded).Select(s => (t.TargetId, s.Scope)))
+                .ToHashSet();
+            var (by, asc) = (SortBy, SortAscending);
+
+            var (rows, merges) = await Task.Run(async () =>
+            {
+                await _gate.WaitAsync();
+                try
+                {
+                    _resolution.EnsureTargetsResolved();
+                    var built = _query.GetTargetGoals().Select(t => BuildRow(t, by, asc)).ToList();
+                    // Unset bars scale to the largest REAL target's hours (the "% of largest"
+                    // view); exclude the synthetic "(Unnamed)" pile (TargetId 0), often the
+                    // biggest, so real bars don't shrink against junk. Push the reference onto
+                    // every row so each bar computes it off its own DataContext (no ancestor
+                    // binding in the deferred templates).
+                    var max = built.Where(r => r.TargetId != 0).Select(r => r.Hours).DefaultIfEmpty(0).Max();
+                    foreach (var r in built)
+                    {
+                        r.ReferenceMax = max;
+                        foreach (var s in r.Scopes)
+                        {
+                            s.ReferenceMax = max;
+                            foreach (var f in s.Filters) f.ReferenceMax = max;
+                        }
+                    }
+                    // The active merges for the flyout, built under the same gate/read.
+                    var merges = _resolution.GetMergeOperations()
+                        .Select(o => new MergeOperationRowViewModel
+                        {
+                            OperationId = o.OperationId,
+                            Kind = o.Kind,
+                            Label = $"{string.Join(", ", o.AbsorbedLabels)} → {o.SurvivorLabel}",
+                            UndoAction = UndoMergeRow,
+                        })
+                        .ToList();
+                    return (built, merges);
+                }
+                finally { _gate.Release(); }
+            });
+
+            foreach (var r in rows)
+            {
+                r.IsExpanded = expanded.Contains(r.TargetId);
+                foreach (var s in r.Scopes)
+                    s.IsExpanded = expandedScopes.Contains((r.TargetId, s.Scope));
+            }
+            Targets = new(Order(rows, by, asc));
+            MergeOperations = new(merges);
+            _loaded = true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to load the target summary");
+            try { await _dialogService.ShowMessageDialog("Failed to load the target summary."); }
+            catch (Exception dialogEx) { Log.Error(dialogEx, "Failed to show the target summary error dialog"); }
+        }
+    }
+
+    // Build a target row from the query, wiring each filter's goal persistence, ordering the
+    // filters by the classifier (static) and the scopes by the active sort.
+    private TargetGoalRowViewModel BuildRow(TargetGoal t, TargetSummarySort by, bool asc)
+    {
+        var scopes = Order(
+            t.Scopes.Select(s =>
+            {
+                // The scope's rendered filter labels: a goal edit may only match a row stored
+                // under the bare-B/R flip partner when that partner has no cell of its own here
+                // (mirrors the read-side guard in TargetGoalQuery.LookupGoal).
+                var cellLabels = s.Filters.Select(f => f.Filter).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                return new ScopeGoalRowViewModel
+                {
+                    Scope = s.Scope,
+                    First = s.First,
+                    Last = s.Last,
+                    Filters = s.Filters
+                        .OrderBy(f => FilterClassifier.SortKey(f.Filter))
+                        .Select(f => new FilterGoalRowViewModel
+                        {
+                            TargetId = t.TargetId,
+                            Scope = s.Scope,
+                            Filter = f.Filter,
+                            Hours = f.Hours,
+                            ExplicitGoal = f.ExplicitGoal,
+                            PersistGoal = PersistFilterGoal,
+                            AllowFlipPartnerMatch = FilterCanonicalizer.FlipPartnerOf(f.Filter) is { } p && !cellLabels.Contains(p),
+                        })
+                        .ToList(),
+                };
+            }),
+            by, asc, s => s.Scope, s => s.Hours, s => s.Goal, s => s.Remainder, s => s.First, s => s.Last);
+
+        var target = new TargetGoalRowViewModel
+        {
+            TargetId = t.TargetId,
+            CanonicalName = t.CanonicalName,
+            First = t.First,
+            Last = t.Last,
+            Scopes = scopes,
+        };
+        // Each filter recomputes its scope + target bars in memory on a goal edit (live, no reload).
+        foreach (var s in scopes)
+            foreach (var f in s.Filters)
+                f.RaiseAncestors = () => { s.RaiseDerived(); target.RaiseDerived(); };
+        return target;
+    }
+
+    // Generic per-layer ordering. Date keys push undated rows last (ascending) via MaxValue.
+    private static List<T> Order<T>(IEnumerable<T> rows, TargetSummarySort by, bool asc,
+        Func<T, string> name, Func<T, double> hours, Func<T, double> goal, Func<T, double> needed,
+        Func<T, DateTime?> first, Func<T, DateTime?> last)
+    {
+        Func<T, IComparable> key = by switch
+        {
+            TargetSummarySort.DataAcquired => r => hours(r),
+            TargetSummarySort.DataNeeded => r => needed(r),
+            TargetSummarySort.Goal => r => goal(r),
+            TargetSummarySort.FirstAcquired => r => first(r) ?? DateTime.MaxValue,
+            TargetSummarySort.LastAcquired => r => last(r) ?? DateTime.MaxValue,
+            _ => r => name(r),
+        };
+        // Alphabetical compares case-insensitively; the others compare their numeric/date key.
+        var ordered = by == TargetSummarySort.Alphabetical
+            ? rows.OrderBy(name, StringComparer.OrdinalIgnoreCase)
+            : rows.OrderBy(key);
+        return (asc ? ordered : ordered.Reverse()).ToList();
+    }
+
+    private static List<TargetGoalRowViewModel> Order(IEnumerable<TargetGoalRowViewModel> rows, TargetSummarySort by, bool asc)
+        => Order(rows, by, asc, r => r.CanonicalName, r => r.Hours, r => r.Goal, r => r.Remainder, r => r.First, r => r.Last);
+
+    protected override void OnInitialActivated()
+    {
+        base.OnInitialActivated();
+        _ = Reload();
+    }
+
+    [RelayCommand]
+    private Task Refresh() => Reload();
+
+    // Wired into each filter row; persists an inline goal edit then reloads so the rolled-up
+    // scope/target bars reflect it. The reload preserves expansion.
+    private async Task PersistFilterGoal(FilterGoalRowViewModel filter)
+    {
+        // Update the scope/target bars live, in memory — NO full reload, so the tree doesn't
+        // collapse, focus stays in the next goal box, and the sort order doesn't shuffle while
+        // editing. The DB write persists it; the next real reload re-reads from there.
+        filter.RaiseAncestors?.Invoke();
+        await UpsertFilterGoal(filter.TargetId, filter.Scope, filter.Filter, filter.ExplicitGoal, filter.AllowFlipPartnerMatch);
+    }
+
+    // Upsert one per-(target, scope, filter) goal. Gated + try/caught (a LostFocus edit on the
+    // UI thread mustn't crash the tab on SQLITE_BUSY). A zero/negative/null goal deletes.
+    //
+    // The row search matches every stored row this CELL DISPLAYS, not just rows under the
+    // cell's literal key: the read side (TargetGoalQuery) resolves non-destructive merges — a
+    // goal saved under an absorbed scope name or absorbed target id renders on the survivor's
+    // cell — and falls back to the bare-B/R flip partner. If the write side searched only the
+    // literal key, clearing a displayed goal would silently no-op (the row hides under its
+    // pre-merge key and resurrects on the next reload) and editing would fork a twin row
+    // instead of updating the original.
+    private async Task UpsertFilterGoal(int targetId, string scope, string filter, double? goalHours, bool matchFlipPartner)
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            using var db = _dbContextFactory.CreateDbContext();
+            // Same merge resolution the query applies before its goal join. The goals table is
+            // tens of rows (one per explicit goal), so a full tracked read beats expressing
+            // merge resolution in SQL.
+            var scopeMap = MergeResolver.BuildScopeMap(db.ScopeMerges.AsNoTracking().ToList());
+            var targetMap = MergeResolver.BuildTargetMap(db.TargetMerges.AsNoTracking().ToList());
+            string MapScope(string s) => scopeMap.TryGetValue(s.ToLowerInvariant(), out var canon) ? canon : s;
+            int MapTarget(int id) => id != 0 && targetMap.TryGetValue(id, out var sid) ? sid : id;
+            var partner = matchFlipPartner ? FilterCanonicalizer.FlipPartnerOf(filter) : null;
+            bool LabelMatches(string f) => string.Equals(f, filter, StringComparison.OrdinalIgnoreCase)
+                || (partner is not null && string.Equals(f, partner, StringComparison.OrdinalIgnoreCase));
+            var matches = db.TargetFilterGoals
+                .AsEnumerable()
+                .Where(g => MapTarget(g.TargetId) == targetId
+                         && string.Equals(MapScope(g.Scope), scope, StringComparison.OrdinalIgnoreCase)
+                         && LabelMatches(g.Filter))
+                .ToList();
+
+            if (goalHours is > 0)
+            {
+                // Prefer the row already stored under the cell's exact key; else reuse the
+                // first match (a partner-labelled or pre-merge row). A kept non-exact row is
+                // re-keyed to the rendered cell so it stops hiding; any other matches are
+                // strands a merge made equivalent — removed in the SAME SaveChanges, so the
+                // unique (TargetId, Scope, Filter) index never sees a transient duplicate
+                // (the same batching AbsorbInto relies on). No same-batch key collision is
+                // possible: only the kept row is re-keyed, and an exact-key row is always
+                // preferred as the kept row.
+                var keep = matches.FirstOrDefault(g => g.TargetId == targetId
+                                                    && string.Equals(g.Scope, scope, StringComparison.OrdinalIgnoreCase)
+                                                    && string.Equals(g.Filter, filter, StringComparison.OrdinalIgnoreCase))
+                    ?? matches.FirstOrDefault();
+                if (keep is null)
+                {
+                    db.TargetFilterGoals.Add(new TargetFilterGoal { TargetId = targetId, Scope = scope, Filter = filter, GoalHours = goalHours.Value });
+                }
+                else
+                {
+                    keep.GoalHours = goalHours.Value;
+                    keep.TargetId = targetId;
+                    keep.Scope = scope;
+                    keep.Filter = filter;   // also normalizes casing on an exact match
+                    foreach (var extra in matches.Where(m => m != keep))
+                        db.TargetFilterGoals.Remove(extra);
+                }
+            }
+            else
+            {
+                // Clearing removes EVERY row the cell displayed — deleting just one would let
+                // a stranded partner/pre-merge row resurrect the goal on the next reload.
+                db.TargetFilterGoals.RemoveRange(matches);
+            }
+            await db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to save the goal for target {TargetId} scope {Scope} filter {Filter}", targetId, scope, filter);
+            await _dialogService.ShowMessageDialog("Failed to save the goal.");
+        }
+        finally { _gate.Release(); }
+    }
+
+    // Merge the currently-selected rows into one target.
+    [RelayCommand]
+    private async Task MergeSelected()
+    {
+        var selected = Targets.Where(t => t.IsSelected && t.TargetId != 0).ToList();
+        if (selected.Count < 2)
+        {
+            await _dialogService.ShowMessageDialog("Select at least two targets to merge.");
+            return;
+        }
+
+        // The most-integrated row is the survivor and supplies the name; ThenBy name breaks
+        // equal-total ties deterministically.
+        var ordered = selected.OrderByDescending(t => t.Hours).ThenBy(t => t.CanonicalName).ToList();
+        var canonical = ordered[0].CanonicalName;
+        try
+        {
+            await _gate.WaitAsync();
+            try { _resolution.MergeTargets(ordered.Select(t => t.TargetId).ToList(), canonical); }
+            finally { _gate.Release(); }
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to merge the selected targets");
+            await _dialogService.ShowMessageDialog("Failed to merge the selected targets.");
+        }
+    }
+
+    // Fold the selected scope rows (telescope-name variants) into one. A scope merge is GLOBAL — it
+    // folds the name everywhere it appears — so it gathers selected scopes across every target. The
+    // most-integrated spelling is the survivor; the rest fold into it. Non-destructive (a record
+    // resolved at query time), reversible from the Manage-merges flyout.
+    [RelayCommand]
+    private async Task MergeScopes()
+    {
+        var selected = Targets.SelectMany(t => t.Scopes).Where(s => s.IsSelected).ToList();
+        var names = selected.Select(s => s.Scope).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (names.Count < 2)
+        {
+            await _dialogService.ShowMessageDialog("Select at least two scope rows to merge.");
+            return;
+        }
+
+        // Survivor = the most-integrated spelling (summed across its selected rows); ThenBy name
+        // breaks ties deterministically.
+        var canonical = selected
+            .GroupBy(s => s.Scope, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(g => g.Sum(s => s.Hours))
+            .ThenBy(g => g.Key)
+            .First().Key;
+        var absorbed = names.Where(n => !string.Equals(n, canonical, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        try
+        {
+            await _gate.WaitAsync();
+            try { _resolution.MergeScopes(canonical, absorbed); }
+            finally { _gate.Release(); }
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to merge the selected scopes");
+            await _dialogService.ShowMessageDialog("Failed to merge the selected scopes.");
+        }
+    }
+
+    // Reverse one merge (scope or target) from the Manage-merges flyout — remove its records and
+    // reload, so the folded scopes/targets reappear. Assigned to each MergeOperationRowViewModel.
+    private async Task UndoMergeRow(MergeOperationRowViewModel row)
+    {
+        try
+        {
+            await _gate.WaitAsync();
+            try { _resolution.UndoMerge(row.OperationId); }
+            finally { _gate.Release(); }
+            await Reload();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to undo merge {OperationId}", row.OperationId);
+            await _dialogService.ShowMessageDialog("Failed to undo the merge.");
+        }
+    }
+}


### PR DESCRIPTION
# PR: Target Summary

## What?

This PR adds a new "Target Summary" page, accessible via the Target icon on the left-side
Navbar.  This page displays all targets a user has data for, and a visual representation
of the acquisition time captured for each, color-coded per filter.  Each Target listed
breaks down into sub-listings of Telescope (where data from multiple scopes exists) and
Filter. Targets and Telescopes are name-normalized around slight variations (e.g. Bode's
vs bode's vs bodes), with further manual merge capabilities for missed cases, with full 
revert capability in case of accidental merges.  Each filter can have a goal set, which
rolls up into the Telescope and Target layers in aggregate.

## Why?

My main frustration with Lumidex has been that can't just look at my library and know
what I have. I have to remember my aliases, run a search, and even then I only see the
one target I searched for. And because NINA lets me type whatever I want for the object
name, the same target fragments across spellings — "M 31", "M31", "Andromeda" — so no
single view ever shows the whole picture. I wanted one place that answers: what have I
shot, how much, in which filters, and how much more do I need.

## How?

The tab lists every target by its FITS OBJECT header name, with a color-coded bar of
integration time per filter. A target with data from more than one scope expands into a
per-scope then per-filter breakdown. Filter names are canonicalized so synonyms merge
(Ha/H, Lum/L) while the imaging and photometric systems stay distinct.

Each filter can take an integration goal; the goal rolls up per-scope then per-target,
and the bar fills toward it. A checkbox is included on each Telescope and Target, which
drives the "Merge" buttons.  A merge is fully reversible: undo restores the originals, 
so a wrong merge never results in data loss.

All of this lives in five new tables — targets, name mappings, per-filter goals, and the
two merge records — created by a single additive migration that runs at startup. Nothing
in the existing schema is modified, and no existing rows are touched.

## Screenshots?

<img width="2779" height="1255" alt="Screenshot_20260622_201216" src="https://github.com/user-attachments/assets/006e623c-5c58-46d6-964e-f5c5769dfd52" />


## Testing?

Automated tests cover the aggregation, the filter canonicalization, the goal rollup, and
the merge/undo. Beyond that I ran it on my own library and worked iterated through all
known and observed issues hit. That said, I've only tested on Fedora 44 KDE, not Windows 
or Mac.

## Anything Else?

It's a large feature — happy to walk through any part of it. The merge is deliberately
non-destructive: I'd rather it never silently drop data than save a row. Built with AI
assistance (Claude), reviewed before opening.
