### PR TITLE
Resolve the cfitsio native library on Linux

### DIFF
--- a/Lumidex.Core/Bootstrapper.cs
+++ b/Lumidex.Core/Bootstrapper.cs
@@ -55,6 +55,20 @@ public static class Bootstrapper
 
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
+        var path = GetNativeLibraryPath(libraryName);
+        if (path is null)
+            return IntPtr.Zero;
+
+        NativeLibrary.TryLoad(path, assembly, searchPath, out IntPtr handle);
+        return handle;
+    }
+
+    // Builds the absolute path to a bundled native library:
+    //   <app base>/runtimes/<portable-rid>/native/<prefix><name><ext>
+    // Returns null for platforms with no bundled library, leaving resolution to
+    // the runtime's default search (which then fails loudly, as before).
+    private static string? GetNativeLibraryPath(string libraryName)
+    {
         var prefix = string.Empty;
         var extension = ".dll";
 
@@ -69,8 +83,37 @@ public static class Bootstrapper
             extension = ".dylib";
         }
 
-        IntPtr handle = IntPtr.Zero;
-        NativeLibrary.TryLoad($"./runtimes/{RuntimeInformation.RuntimeIdentifier}/native/{prefix}{libraryName}{extension}", assembly, searchPath, out handle);
-        return handle;
+        // Resolve the portable RID whose runtimes/<rid>/native/ folder we ship.
+        // RuntimeInformation.RuntimeIdentifier is unusable here: on Linux it is
+        // the distro-specific RID (e.g. "fedora.44-x64"), which has no matching
+        // runtimes/ folder, so the load silently misses. It only happens to line
+        // up on Windows ("win-x64") — which is why this bug is Linux-only.
+        var rid = GetNativeRuntimeIdentifier();
+        if (rid is null)
+            return null;
+
+        // Anchor at the app's base directory, not "./". A relative path resolves
+        // against the current working directory, which equals the app folder
+        // only when launched from it (e.g. `dotnet run`). An installed build
+        // started from a .desktop entry or any other CWD would miss the lib.
+        return Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", $"{prefix}{libraryName}{extension}");
+    }
+
+    // Maps OS + process architecture to the portable RID we bundle a native
+    // cfitsio for. Returns null for platforms with no bundled library, leaving
+    // resolution to the runtime's default search (which then fails loudly with
+    // DllNotFoundException, as before).
+    private static string? GetNativeRuntimeIdentifier()
+    {
+        var arch = RuntimeInformation.ProcessArchitecture;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && arch is Architecture.X64)
+            return "win-x64";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && arch is Architecture.X64)
+            return "linux-x64";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return arch is Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+
+        return null;
     }
 }

--- a/Lumidex.Tests/NativeLibraryResolverTests.cs
+++ b/Lumidex.Tests/NativeLibraryResolverTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Lumidex.Tests;
+
+// Regression guard for the cfitsio native-load bug on published Linux builds.
+//
+// The DllImportResolver must build its path from the PORTABLE RID whose
+// runtimes/<rid>/native/ folder we actually ship (linux-x64, osx-arm64,
+// osx-x64, win-x64) — NOT from RuntimeInformation.RuntimeIdentifier, which on
+// Linux is the distro-specific RID (e.g. "fedora.44-x64", "ubuntu.24.04-x64").
+// That distro RID has no matching runtimes/ folder, so the resolver pointed at
+// a path that never exists and cfitsio failed to load on installed builds.
+//
+// Bootstrapper.GetNativeRuntimeIdentifier is private. We reach it by reflection
+// rather than widening its visibility, so the production diff stays limited to
+// the resolver fix itself.
+public class NativeLibraryResolverTests
+{
+    [Fact]
+    public void GetNativeRuntimeIdentifier_TargetsAShippedPortableRid()
+    {
+        // Fully qualified: there is also a Lumidex.Bootstrapper in the app
+        // assembly, and an unqualified name binds to the wrong one.
+        var method = typeof(Lumidex.Core.Bootstrapper).GetMethod(
+            "GetNativeRuntimeIdentifier",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("the resolver must map OS + architecture to a portable RID");
+
+        var rid = (string?)method!.Invoke(null, parameters: null);
+
+        // The four RIDs Lumidex.Core ships a native cfitsio under.
+        string[] shippedRids = ["linux-x64", "osx-arm64", "osx-x64", "win-x64"];
+        rid.Should().BeOneOf(shippedRids);
+
+        // The field failure was Linux-only: linux-x64 is the single Linux folder
+        // we ship, so the distro-specific RID must never be what gets used. This
+        // assertion holds on every Linux distro (it asserts the portable result,
+        // not the absence of any particular distro string).
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            rid.Should().Be("linux-x64");
+    }
+
+    // Guards the SECOND half of the same fix: the load path must be anchored at
+    // the app base directory, not the current working directory. The field bug
+    // had two compounding causes — the wrong RID (above) and a "./"-relative
+    // path that missed whenever an installed build was launched from a CWD other
+    // than its own folder. A regression reverting only the anchoring would leave
+    // the RID test green, so it needs its own assertion.
+    [Fact]
+    public void GetNativeLibraryPath_IsRootedAtAppBaseUnderTheShippedRid()
+    {
+        var method = typeof(Lumidex.Core.Bootstrapper).GetMethod(
+            "GetNativeLibraryPath",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull("the resolver must anchor the native path at the app base directory");
+
+        var path = (string?)method!.Invoke(null, parameters: ["cfitsio"]);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            path.Should().NotBeNull();
+            Path.IsPathRooted(path).Should().BeTrue("a CWD-relative path is exactly the bug being fixed");
+            path!.Should().StartWith(AppContext.BaseDirectory);
+            path.Should().Contain(Path.Combine("runtimes", "linux-x64", "native"));
+            path.Should().EndWith("libcfitsio.so");
+        }
+    }
+}


### PR DESCRIPTION
## What?

Fix the native FITS library (cfitsio) failing to load on Linux, which crashes the app at
startup.

## Why?

On Linux the app dies immediately with a `DllNotFoundException` for libcfitsio. It looks
for the native library under a runtime-specific folder (e.g. `fedora.44-x64`) that
doesn't match the portable folder the build actually ships (`linux-x64`), and it builds
that path relative to the working directory rather than the app. So the library is right
there in the install, but the app never finds it. I hit this on my own Fedora machine
and had to copy the `.so` into place by hand to get the app to start.

## How?

The `DllImport` resolver now maps the OS and architecture to the portable runtime
identifier the build ships, and anchors the lookup at the application base directory
instead of the working directory. It finds the bundled native library regardless of
where the app is launched from or which distro it runs on.

## Testing?

The app now starts cleanly on Fedora with no manual workaround. Unit tests cover the
runtime-identifier mapping and the base-directory anchoring.

## Anything Else?

This only touches the native-library resolution path; nothing changes for Windows or Mac,
which already worked. Built with AI assistance (Claude), tested on Linux.
