### PR TITLE
Fix two KDE Plasma 6 startup crashes

### DIFF
--- a/Lumidex.Desktop/Program.cs
+++ b/Lumidex.Desktop/Program.cs
@@ -42,6 +42,14 @@ class Program
 
         return AppBuilder.Configure<App>()
                 .UsePlatformDetect()
+                // Disable Avalonia's Linux global-menu (DBus app-menu) export. It targets
+                // com.canonical.AppMenu.Registrar, which KDE Plasma 6 neither owns nor makes
+                // activatable (it uses org.kde.kappmenu + a gmenu proxy instead), so the
+                // export raises an unobserved DBus "ServiceUnknown: The name is not
+                // activatable" task that the finalizer would otherwise turn fatal. Our
+                // NativeMenu is empty, so nothing is lost by not exporting it. This is an
+                // X11-only option, so Windows and macOS are unaffected.
+                .With(new X11PlatformOptions { UseDBusMenu = false })
                 .WithInterFont()
                 .LogToTrace();
     }

--- a/Lumidex/Bootstrapper.cs
+++ b/Lumidex/Bootstrapper.cs
@@ -49,10 +49,18 @@ public static class Bootstrapper
 
     private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
     {
+        // Observe and log unobserved task exceptions without rethrowing. Returning
+        // false makes AggregateException.Handle RE-THROW the exception; here that runs
+        // on the finalizer thread, which escalates a benign unobserved exception into a
+        // fatal appdomain crash. On Linux this fires readily — Avalonia's D-Bus platform
+        // integration raises fire-and-forget exceptions when a desktop service isn't
+        // reachable (e.g. "org.freedesktop.DBus.Error.ServiceUnknown: The name is not
+        // activatable" for an accessibility/portal bus). Returning true marks it handled
+        // so the app logs and keeps running, which is the evident intent of logging here.
         e.Exception.Handle(ex =>
         {
             Log.Error(ex, "Unobserved task exception");
-            return false;
+            return true;
         });
     }
 }


### PR DESCRIPTION
## What?

Fix two startup crashes on KDE Plasma 6.

## Why?

On KDE Plasma 6 the app crashes at launch. There are two separate causes: it tries to
export its menu over a D-Bus global-menu service that Plasma 6 doesn't provide, and an
unobserved background-task exception is rethrown in a way that takes the whole app down
instead of being logged. The global-menu crash is the one reported in #131 (App Crash on
Kubuntu — the `com.canonical.AppMenu.Registrar` D-Bus error). Closes #131.

## How?

Two small changes. Disable the global-menu D-Bus export — the menu falls back to the
in-window menu bar, which works everywhere. And change the unobserved-task handler to
mark the exception observed and log it rather than rethrow, so a stray background
exception is recorded instead of fatal.

## Testing?

The app now launches cleanly on Fedora / KDE Plasma 6 where it previously crashed.

## Anything Else?

Both are Linux/KDE-specific and don't change behaviour on Windows or Mac. I grouped them
because from the user's side they're the same "won't start on KDE" symptom, but they're
independent changes if you'd rather split them. Built with AI assistance (Claude), tested
on Linux.
