### PR TITLE
Implement the Linux "Open In" actions (browser, file manager, PixInsight)

### DIFF
--- a/Lumidex/Features/MainSearch/SearchResultsViewModel.cs
+++ b/Lumidex/Features/MainSearch/SearchResultsViewModel.cs
@@ -370,6 +370,14 @@ public partial class SearchResultsViewModel : ViewModelBase,
             {
                 pixPath = @"/Applications/PixInsight/PixInsight.app/Contents/MacOS/PixInsight";
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Launch via the .sh wrapper, not the bare binary: it exports
+                // LD_LIBRARY_PATH for PixInsight's bundled libs (and is what the
+                // installed .desktop file uses). The bare binary can't find them
+                // and exits before opening a window.
+                pixPath = "/opt/PixInsight/bin/PixInsight.sh";
+            }
 
             await _systemService.StartProcess(pixPath, $"\"{fileInfo.FullName}\"");
         }

--- a/Lumidex/Services/SystemService.cs
+++ b/Lumidex/Services/SystemService.cs
@@ -24,6 +24,10 @@ public class SystemService
         {
             await StartProcess("open", $"-u \"{url}\"");
         }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            await LaunchDetached("xdg-open", url);
+        }
         else
         {
             await _dialogService.ShowMessageDialog($"{nameof(OpenUrl)} not implemented for {RuntimeInformation.OSDescription}");
@@ -40,9 +44,81 @@ public class SystemService
         {
             await StartProcess("open", $"-R \"{path}\"");
         }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            await ShowInFileManager(path);
+        }
         else
         {
             await _dialogService.ShowMessageDialog($"{nameof(OpenInExplorer)} not implemented for {RuntimeInformation.OSDescription}");
+        }
+    }
+
+    // Linux equivalent of "reveal in file manager". Windows /select and macOS -R
+    // both highlight the file inside its folder; the freedesktop
+    // org.freedesktop.FileManager1.ShowItems D-Bus method does the same and is
+    // honored by Dolphin, Nautilus, Nemo and Caja. When that interface isn't
+    // available (a minimal file manager, no D-Bus session) the call exits
+    // non-zero and we fall back to opening the containing folder with xdg-open,
+    // so the action still does something useful everywhere.
+    private async Task ShowInFileManager(string path)
+    {
+        // ShowItems takes file:// URIs. TryCreate yields a percent-encoded
+        // absolute URI (handling spaces etc.) and returns false rather than
+        // throwing for a relative/malformed path — in which case we skip D-Bus
+        // and just open the containing folder.
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri))
+        {
+            // Args go through ArgumentList (not a single string) so the GVariant
+            // array literal and empty startup-id reach gdbus verbatim, without
+            // the shell-quoting pitfalls of the Process.Start(file, args) overload.
+            var startInfo = new ProcessStartInfo("gdbus") { UseShellExecute = false };
+            startInfo.ArgumentList.Add("call");
+            // Bound the wait so a wedged FileManager1 provider can't hang the
+            // reveal — gdbus exits non-zero on timeout, routing us to the
+            // xdg-open fallback below.
+            startInfo.ArgumentList.Add("--timeout");
+            startInfo.ArgumentList.Add("5");
+            startInfo.ArgumentList.Add("--session");
+            startInfo.ArgumentList.Add("--dest");
+            startInfo.ArgumentList.Add("org.freedesktop.FileManager1");
+            startInfo.ArgumentList.Add("--object-path");
+            startInfo.ArgumentList.Add("/org/freedesktop/FileManager1");
+            startInfo.ArgumentList.Add("--method");
+            startInfo.ArgumentList.Add("org.freedesktop.FileManager1.ShowItems");
+            // uris: a one-element array. AbsoluteUri is percent-encoded, so any
+            // ", [ or ] in the source path is escaped and can't break out of the
+            // GVariant literal to inject extra array elements or arguments.
+            startInfo.ArgumentList.Add($"[\"{uri.AbsoluteUri}\"]");
+            startInfo.ArgumentList.Add("\"\"");                      // startup-id: empty
+
+            if (await RunToCompletion(startInfo))
+                return;
+        }
+
+        var parent = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(parent))
+            await LaunchDetached("xdg-open", parent);
+    }
+
+    // Runs a process to completion and reports whether it exited successfully.
+    // StartProcess is fire-and-forget; ShowInFileManager needs the exit code to
+    // know whether the D-Bus reveal worked before deciding to fall back.
+    private async Task<bool> RunToCompletion(ProcessStartInfo startInfo)
+    {
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process is null)
+                return false;
+
+            await process.WaitForExitAsync();
+            return process.ExitCode == 0;
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Failed to run {Process}", startInfo.FileName);
+            return false;
         }
     }
 
@@ -55,6 +131,28 @@ public class SystemService
         catch (Exception e)
         {
             Log.Error(e, "Failed to start {Process} {Argument}", executable, args);
+            await _dialogService.ShowMessageDialog($"Failed to start {executable}");
+        }
+    }
+
+    // Fire-and-forget launch that passes each argument individually through
+    // ArgumentList. StartProcess takes a single arguments string, which is fine
+    // for the fixed Windows/macOS invocations but tokenizes embedded quotes —
+    // a path or URL containing a `"` can split into extra argv elements there.
+    // The Linux open/reveal actions feed user-derived paths, so they go through
+    // this overload instead, where each argument stays intact.
+    private async Task LaunchDetached(string executable, params string[] arguments)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(executable) { UseShellExecute = false };
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+            Process.Start(startInfo);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Failed to start {Process}", executable);
             await _dialogService.ShowMessageDialog($"Failed to start {executable}");
         }
     }


### PR DESCRIPTION
## What?

Implement the three "Open In" actions on Linux: open a URL in the browser, reveal a file in
the system file manager, and open a file in PixInsight. Until now the first two show a "not
implemented" dialog and the PixInsight action has no Linux path at all.

Closes #136.

## Why?

A few places in the app offer to open a URL, show a file in the system file manager, or open
an image in PixInsight. On Windows and Mac these work; on Linux the first two pop a "not
implemented" message and the PixInsight action does nothing. #136 asks for all three, so this
covers the whole issue.

## How?

Opening a URL goes through `xdg-open`. Revealing a file uses the freedesktop
`org.freedesktop.FileManager1` D-Bus interface (via gdbus) so the file manager opens with the
file selected, and falls back to `xdg-open` on the parent folder if that interface isn't
available. Opening in PixInsight launches `/opt/PixInsight/bin/PixInsight.sh` — the launcher
the installed `.desktop` file uses, which sets up `LD_LIBRARY_PATH` for PixInsight's bundled
libraries. Paths are passed as separate arguments rather than interpolated into a command
string, so paths with spaces or quotes are handled safely.

## Testing?

Tested on Fedora / KDE: URLs open in the browser, "reveal" opens the file manager with the
file highlighted, and "Open In PixInsight" launches PixInsight with the selected file. The
file-manager fallback was exercised by testing without the FileManager1 interface present.

## Anything Else?

Two deliberate choices. Passing the path as an argument list rather than a single command
string avoids path-injection surprises with odd filenames. And PixInsight is launched via its
`.sh` wrapper rather than the bare `bin/PixInsight`: the bare binary exits with a missing-`.so`
error because only the wrapper exports `LD_LIBRARY_PATH` for its bundled libraries. Built with
AI assistance (Claude), tested on Linux.
