### PR TITLE
Skip hidden directories when walking a library

### DIFF
--- a/Lumidex.Core/IO/DirectoryWalker.cs
+++ b/Lumidex.Core/IO/DirectoryWalker.cs
@@ -98,6 +98,13 @@ public static class DirectoryWalker
                 if (dir.Name.StartsWith('$'))
                     continue;
 
+                // . are POSIX hidden directories (.git, .cache, .Trash-*, ...).
+                // They hold no library images and can be large, so skip them.
+                // Only descendants are skipped — an explicitly-chosen root that
+                // starts with '.' is still walked (it is pushed before this loop).
+                if (dir.Name.StartsWith('.'))
+                    continue;
+
                 dirStack.Push(dir);
             }
         }

--- a/Lumidex.Tests/DirectoryWalkerDotfileTests.cs
+++ b/Lumidex.Tests/DirectoryWalkerDotfileTests.cs
@@ -1,0 +1,58 @@
+using Lumidex.Core.IO;
+using System.IO.Abstractions;
+
+namespace Lumidex.Tests;
+
+// Uses a real FileSystem with temp directories, matching the existing
+// DirectoryWalker tests — the walk only reads directory/file names here, but a
+// real tree keeps the test consistent with the rest of the walker coverage.
+public class DirectoryWalkerDotfileTests : IDisposable
+{
+    private readonly string _libDir;
+    private readonly IFileSystem _fileSystem = new FileSystem();
+
+    public DirectoryWalkerDotfileTests()
+    {
+        _libDir = Path.Combine(Path.GetTempPath(), $"lumidex-test-dotfiles-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_libDir);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        if (Directory.Exists(_libDir))
+            Directory.Delete(_libDir, recursive: true);
+    }
+
+    // POSIX hidden directories (.git, .cache, .Trash-*, ...) hold no library
+    // images and can be large. The walker must not descend into them.
+    // Pre-fix: only "$"-prefixed dirs are skipped, so the file under .git is
+    // walked and yielded.
+    [Fact]
+    public void Walk_DoesNotDescendIntoDotPrefixedSubdirectories()
+    {
+        Directory.CreateDirectory(Path.Combine(_libDir, ".git"));
+        File.WriteAllText(Path.Combine(_libDir, ".git", "hidden.fits"), "");
+        Directory.CreateDirectory(Path.Combine(_libDir, "normal"));
+        File.WriteAllText(Path.Combine(_libDir, "normal", "visible.fits"), "");
+
+        var yielded = DirectoryWalker.Walk(_fileSystem, _libDir).Select(f => f.Name).ToList();
+
+        yielded.Should().ContainSingle().Which.Should().Be("visible.fits");
+    }
+
+    // The skip applies to descendants discovered during the walk, never to the
+    // explicitly-chosen root. A library rooted at a dot-directory (e.g.
+    // ~/.astrophotos) must still be scanned.
+    [Fact]
+    public void Walk_DoesNotSkipDotPrefixedRoot()
+    {
+        var dotRoot = Path.Combine(_libDir, ".astrophotos");
+        Directory.CreateDirectory(dotRoot);
+        File.WriteAllText(Path.Combine(dotRoot, "image.fits"), "");
+
+        var yielded = DirectoryWalker.Walk(_fileSystem, dotRoot).Select(f => f.Name).ToList();
+
+        yielded.Should().ContainSingle().Which.Should().Be("image.fits");
+    }
+}


### PR DESCRIPTION
## What?

Skip hidden (dot-prefixed) directories when scanning a library folder on Linux.

## Why?

On Linux it's normal to keep an image library under your home directory, which is full
of hidden folders — `.cache`, `.git`, `.local`, and so on. Right now the scanner walks
into all of them, wasting time and occasionally tripping over files it has no business
reading. The code already skips Windows system folders (the `$`-prefixed ones); this is
the POSIX equivalent sitting right next to it.

## How?

One check in the directory walk: if a subdirectory's name starts with `.`, skip it and
its contents. It mirrors the existing `$`-folder skip.

## Testing?

Unit tests confirm dot-directories (and their children) are excluded while normal folders
are still walked.

## Anything Else?

It's a broad skip — I couldn't think of a realistic case where astro data lives behind a
dotfolder, but if you'd rather it be narrower, that's an easy change. Built with AI
assistance (Claude), tested on Linux.
